### PR TITLE
Add option for setting "preferred" backend

### DIFF
--- a/example_experiments/asreader_who_did_what.json
+++ b/example_experiments/asreader_who_did_what.json
@@ -1,6 +1,7 @@
 {
     "model_class": "AttentionSumReader",
     "model_serialization_prefix": "models/multiple_choice_qa/asreader",
+    "preferred_backend": "theano",
     "encoder": {
         "type": "bi_gru",
         "output_dim": 384

--- a/src/main/python/deep_qa/training/trainer.py
+++ b/src/main/python/deep_qa/training/trainer.py
@@ -45,9 +45,23 @@ class Trainer:
         # Preferred backend to use for training. If a different backend is detected, we still
         # train but we also warn the user.
         self.preferred_backend = params.pop('preferred_backend', None)
-        if self.preferred_backend and self.preferred_backend != K.backend():
-            logger.warning("Preferred backend is %s, but current backend is %s.",
-                           self.preferred_backend, K.backend())
+        if self.preferred_backend and self.preferred_backend.lower() != K.backend():
+            warning_info = ("@ Preferred backend is %s, but "
+                            "current backend is %s. @" % (self.preferred_backend.lower(),
+                                                          K.backend()))
+            end_row = "@" * len(warning_info)
+            warning_row_spaces = len(warning_info) - len("@ WARNING: @")
+            left_warning_row_spaces = right_warning_row_spaces = warning_row_spaces // 2
+            if warning_row_spaces % 2 == 1:
+                # left and right have uneven spacing
+                right_warning_row_spaces += 1
+            left_warning_row = "\n@" + " " * left_warning_row_spaces
+            right_warning_row = " " * right_warning_row_spaces + "@\n"
+            warning_message = ("\n" + end_row +
+                               left_warning_row + " WARNING: " + right_warning_row +
+                               warning_info +
+                               "\n" + end_row)
+            logger.warning(warning_message)
 
         # Upper limit on the number of training instances.  If this is set, and we get more than
         # this, we will truncate the data.

--- a/src/main/python/deep_qa/training/trainer.py
+++ b/src/main/python/deep_qa/training/trainer.py
@@ -42,6 +42,13 @@ class Trainer:
             parent_directory = os.path.dirname(self.model_prefix)
             os.makedirs(parent_directory, exist_ok=True)
 
+        # Preferred backend to use for training. If a different backend is detected, we still
+        # run the training but warn the user.
+        self.preferred_backend = params.pop('preferred_backend', None)
+        if self.preferred_backend and self.preferred_backend != K.backend():
+            logger.warn("Preferred backend is %s, but current backend is %s." %
+                        (self.preferred_backend, K.backend()))
+
         # Upper limit on the number of training instances.  If this is set, and we get more than
         # this, we will truncate the data.
         self.max_training_instances = params.pop('max_training_instances', None)

--- a/src/main/python/deep_qa/training/trainer.py
+++ b/src/main/python/deep_qa/training/trainer.py
@@ -47,7 +47,7 @@ class Trainer:
         self.preferred_backend = params.pop('preferred_backend', None)
         if self.preferred_backend and self.preferred_backend != K.backend():
             logger.warning("Preferred backend is %s, but current backend is %s.",
-                           (self.preferred_backend, K.backend()))
+                           self.preferred_backend, K.backend())
 
         # Upper limit on the number of training instances.  If this is set, and we get more than
         # this, we will truncate the data.

--- a/src/main/python/deep_qa/training/trainer.py
+++ b/src/main/python/deep_qa/training/trainer.py
@@ -43,11 +43,11 @@ class Trainer:
             os.makedirs(parent_directory, exist_ok=True)
 
         # Preferred backend to use for training. If a different backend is detected, we still
-        # run the training but warn the user.
+        # train but we also warn the user.
         self.preferred_backend = params.pop('preferred_backend', None)
         if self.preferred_backend and self.preferred_backend != K.backend():
-            logger.warn("Preferred backend is %s, but current backend is %s." %
-                        (self.preferred_backend, K.backend()))
+            logger.warning("Preferred backend is %s, but current backend is %s.",
+                           (self.preferred_backend, K.backend()))
 
         # Upper limit on the number of training instances.  If this is set, and we get more than
         # this, we will truncate the data.

--- a/src/main/python/deep_qa/training/trainer.py
+++ b/src/main/python/deep_qa/training/trainer.py
@@ -46,21 +46,8 @@ class Trainer:
         # train but we also warn the user.
         self.preferred_backend = params.pop('preferred_backend', None)
         if self.preferred_backend and self.preferred_backend.lower() != K.backend():
-            warning_info = ("@ Preferred backend is %s, but "
-                            "current backend is %s. @" % (self.preferred_backend.lower(),
-                                                          K.backend()))
-            end_row = "@" * len(warning_info)
-            warning_row_spaces = len(warning_info) - len("@ WARNING: @")
-            left_warning_row_spaces = right_warning_row_spaces = warning_row_spaces // 2
-            if warning_row_spaces % 2 == 1:
-                # left and right have uneven spacing
-                right_warning_row_spaces += 1
-            left_warning_row = "\n@" + " " * left_warning_row_spaces
-            right_warning_row = " " * right_warning_row_spaces + "@\n"
-            warning_message = ("\n" + end_row +
-                               left_warning_row + " WARNING: " + right_warning_row +
-                               warning_info +
-                               "\n" + end_row)
+            warning_message = self._make_backend_warning(self.preferred_backend.lower(),
+                                                         K.backend())
             logger.warning(warning_message)
 
         # Upper limit on the number of training instances.  If this is set, and we get more than
@@ -536,6 +523,24 @@ class Trainer:
         model_config_file = open("%s_config.json" % (self.model_prefix), "w")
         print(model_config, file=model_config_file)
         model_config_file.close()
+
+    def _make_backend_warning(self, preferred_backend, actual_backend):
+        warning_info = ("@ Preferred backend is %s, but "
+                        "current backend is %s. @" % (preferred_backend,
+                                                      actual_backend))
+        end_row = "@" * len(warning_info)
+        warning_row_spaces = len(warning_info) - len("@ WARNING: @")
+        left_warning_row_spaces = right_warning_row_spaces = warning_row_spaces // 2
+        if warning_row_spaces % 2 == 1:
+            # left and right have uneven spacing
+            right_warning_row_spaces += 1
+        left_warning_row = "\n@" + " " * left_warning_row_spaces
+        right_warning_row = " " * right_warning_row_spaces + "@\n"
+        warning_message = ("\n" + end_row +
+                           left_warning_row + " WARNING: " + right_warning_row +
+                           warning_info +
+                           "\n" + end_row)
+        return warning_message
 
     @classmethod
     def _get_custom_objects(cls):

--- a/src/main/python/deep_qa/training/trainer.py
+++ b/src/main/python/deep_qa/training/trainer.py
@@ -524,7 +524,8 @@ class Trainer:
         print(model_config, file=model_config_file)
         model_config_file.close()
 
-    def _make_backend_warning(self, preferred_backend, actual_backend):
+    @staticmethod
+    def _make_backend_warning(preferred_backend, actual_backend):
         warning_info = ("@ Preferred backend is %s, but "
                         "current backend is %s. @" % (preferred_backend,
                                                       actual_backend))


### PR DESCRIPTION
This PR lets you specify a preferred backend in the json, and a warning will be displayed if the experiment is run with a different backend (but it'll still run).

this is motivated by my recent experience with the attention sum reader --- the theano model trains quite well and gets around 0.55 keras val accuracy (comparable to published result), but the tensorflow backend doesn't seem to learn anything and just stagnates at 0.38 accuracy. Thus, as the writer of the experiment i'd like to strongly using theano to run it, and i would set this parameter.