### PR TITLE
Add scripts to run circleci doc builds

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -x
+set -e
+
+MAKE_TARGET=html
+
+# deactivate circleci virtualenv and setup a miniconda env instead
+if [[ `type -t deactivate` ]]; then
+  deactivate
+fi
+
+# Install dependencies with miniconda
+pushd .
+cd
+mkdir -p download
+cd download
+echo "Cached in $HOME/download :"
+ls -l
+if [[ ! -f miniconda.sh ]]
+then
+   wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh \
+   -O miniconda.sh
+fi
+chmod +x miniconda.sh && ./miniconda.sh -b -p $MINICONDA_PATH
+cd ..
+export PATH="$MINICONDA_PATH/bin:$PATH"
+conda update --yes --quiet conda
+popd
+
+# Configure the conda environment and put it in the path using the
+# provided versions.
+conda create -n $CONDA_ENV_NAME --yes --quiet python=3.5
+source activate testenv
+
+# Install pip dependencies.
+pip install -r requirements.txt
+
+# The pipefail is requested to propagate exit code
+set -o pipefail && cd doc && make $MAKE_TARGET 2>&1 | tee ~/log.txt
+
+cd -
+set +o pipefail
+
+echo "Finished building docs."
+echo "Artifacts in $CIRCLE_ARTIFACTS"

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,25 @@
+machine:
+  environment:
+    MINICONDA_PATH: $HOME/miniconda
+    CONDA_ENV_NAME: testenv
+
+dependencies:
+  cache_directories:
+    - "~/.cache/pip"
+    - "~/download"
+  # Check whether the doc build is required, install build dependencies and
+  # run sphinx to build the doc.
+  override:
+    - bash build_tools/circle/build_doc.sh:
+        timeout: 3600 # seconds
+
+test:
+  override:
+    - |
+      export PATH="$MINICONDA_PATH/bin:$PATH"
+      source activate $CONDA_ENV_NAME
+general:
+  # Open the built docs to the CircleCI API
+  artifacts:
+    - "doc/_build/html"
+    - "~/log.txt"


### PR DESCRIPTION
This PR adds the necessary files to build our docs on circleCI. These tests will fail if sphinx is unable to build the docs (error, as opposed to many warnings) / doctests fail (though we don't have any right now).

CircleCI has a nice feature with artifacts, that lets you view the built doc as made by circleci without pushing this to master (in order to build it on readthedocs). to access the doc artifact, just access:
https://${CIRCLECI_BUILD_NUM}-76925733-gh.circle-artifacts.com/0/home/ubuntu/deep_qa/doc/_build/html/index.html

note that circleci build number != github pull request number. Here's an example it built on my own fork:
https://4-76925733-gh.circle-artifacts.com/0/home/ubuntu/deep_qa/doc/_build/html/index.html
