### PR TITLE
Enable evaluation of models on test set in Python code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
   directories:
   - /home/travis/nltk_data
   - /home/travis/download
+  - /home/travis/miniconda3
   - /home/travis/.cache/pip
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ cache:
   directories:
   - /home/travis/nltk_data
   - /home/travis/download
-  - /home/travis/miniconda3
   - /home/travis/.cache/pip
 
 env:

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -47,6 +47,3 @@ pip install -r requirements.txt
 
 # Install punkt tokenizer
 python -m nltk.downloader punkt
-
-# Install spacy data
-python -m spacy.en.download all

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -47,3 +47,6 @@ pip install -r requirements.txt
 
 # Install punkt tokenizer
 python -m nltk.downloader punkt
+
+# Install spacy data
+python -m spacy.en.download all

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -43,9 +43,13 @@ else
 fi
 
 # Install requirements via pip in our conda environment
-pip install -r requirements.txt
+pip install -U -r requirements.txt
 
+# List the packages to get their versions for debugging
 pip list
 
 # Install punkt tokenizer
 python -m nltk.downloader punkt
+
+# Install spacy data
+python -m spacy.en.download all

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -45,5 +45,7 @@ fi
 # Install requirements via pip in our conda environment
 pip install -r requirements.txt
 
+pip list
+
 # Install punkt tokenizer
 python -m nltk.downloader punkt

--- a/build_tools/travis/test_script.sh
+++ b/build_tools/travis/test_script.sh
@@ -14,7 +14,7 @@ run_tests() {
     if [[ "$KERAS_BACKEND" == "tensorflow" ]]; then
         KERAS_BACKEND=tensorflow py.test -v --cov=deep_qa --durations=20
     else
-        KERAS_BACKEND=theano OMP_NUM_THREADS=4 THEANO_FLAGS='optimizer=fast_compile,openmp=True' py.test -v --cov=deep_qa --durations=20
+        KERAS_BACKEND=theano THEANO_FLAGS='optimizer=fast_compile' py.test -v --cov=deep_qa --durations=20
     fi
 }
 

--- a/deep_qa/layers/encoders/positional_encoder.py
+++ b/deep_qa/layers/encoders/positional_encoder.py
@@ -44,6 +44,7 @@ class PositionalEncoder(Layer):
         return (input_shape[0], input_shape[2])  # removing second dimension
 
     def call(self, x, mask=None):
+        # pylint: disable=redefined-variable-type
 
         def my_keras_cumsum(tensor, axis=0):
             """
@@ -78,9 +79,7 @@ class PositionalEncoder(Layer):
             one_over_m = ones_like_x / masked_m
             j_index = my_keras_cumsum(ones_like_x, 1)
         else:
-            # pylint: disable=redefined-variable-type
             one_over_m = switch(ones_like_x, ones_like_x/masked_m, K.zeros_like(ones_like_x))
-            # pylint: enable=redefined-variable-type
 
             j_index = my_keras_cumsum(ones_like_x, 1) * K.expand_dims(float_mask, 2)
 

--- a/deep_qa/layers/encoders/positional_encoder.py
+++ b/deep_qa/layers/encoders/positional_encoder.py
@@ -78,7 +78,9 @@ class PositionalEncoder(Layer):
             one_over_m = ones_like_x / masked_m
             j_index = my_keras_cumsum(ones_like_x, 1)
         else:
+            # pylint: disable=redefined-variable-type
             one_over_m = switch(ones_like_x, ones_like_x/masked_m, K.zeros_like(ones_like_x))
+            # pylint: disable=redefined-variable-type
 
             j_index = my_keras_cumsum(ones_like_x, 1) * K.expand_dims(float_mask, 2)
 

--- a/deep_qa/layers/encoders/positional_encoder.py
+++ b/deep_qa/layers/encoders/positional_encoder.py
@@ -80,7 +80,7 @@ class PositionalEncoder(Layer):
         else:
             # pylint: disable=redefined-variable-type
             one_over_m = switch(ones_like_x, ones_like_x/masked_m, K.zeros_like(ones_like_x))
-            # pylint: disable=redefined-variable-type
+            # pylint: enable=redefined-variable-type
 
             j_index = my_keras_cumsum(ones_like_x, 1) * K.expand_dims(float_mask, 2)
 

--- a/deep_qa/training/trainer.py
+++ b/deep_qa/training/trainer.py
@@ -77,6 +77,10 @@ class Trainer:
         # the `keras_validation_split` parameter to split the training data for validation.
         self.validation_files = params.pop('validation_files', None)
 
+        # The files containing the data that should be used for evaluation.
+        # The default of None mean to just not perform test set evaluation.
+        self.test_files = params.pop('test_files', None)
+
         optimizer_params = params.pop('optimizer', 'adam')
         self.optimizer = optimizer_from_params(optimizer_params)
         self.loss = params.pop('loss', 'categorical_crossentropy')
@@ -127,9 +131,15 @@ class Trainer:
         self.training_dataset = None
         self.train_input = None
         self.train_labels = None
+
         self.validation_dataset = None
         self.validation_input = None
         self.validation_labels = None
+
+        self.test_dataset = None
+        self.test_input = None
+        self.test_labels = None
+
         self.debug_dataset = None
         self.debug_input = None
 
@@ -223,7 +233,7 @@ class Trainer:
         raise NotImplementedError
 
     def prepare_data(self, train_files, max_training_instances,
-                     validation_files, update_data_indexer=True):
+                     validation_files=None, test_files=None, update_data_indexer=True):
         logger.info("Getting training data")
         training_dataset = self._load_dataset_from_files(train_files)
         if max_training_instances is not None:
@@ -239,8 +249,17 @@ class Trainer:
             validation_input, validation_labels = self._prepare_data(validation_dataset,
                                                                      for_train=False,
                                                                      update_data_indexer=update_data_indexer)
+        test_dataset = test_input = test_labels = None
+        if test_files:
+            logger.info("Getting test data")
+            test_dataset = self._load_dataset_from_files(test_files)
+            test_input, test_labels = self._prepare_data(validation_dataset,
+                                                         for_train=False,
+                                                         update_data_indexer=update_data_indexer)
+
         return ((training_dataset, train_input, train_labels),
-                (validation_dataset, validation_input, validation_labels))
+                (validation_dataset, validation_input, validation_labels),
+                (test_dataset, test_input, test_labels))
 
     def train(self):
         '''
@@ -259,10 +278,12 @@ class Trainer:
             self._process_pretraining_data()
 
         # First we need to prepare the data that we'll use for training.
-        train_data, val_data = self.prepare_data(self.train_files, self.max_training_instances,
-                                                 self.validation_files)
+        train_data, val_data, test_data = self.prepare_data(self.train_files, self.max_training_instances,
+                                                            self.validation_files,
+                                                            self.test_files)
         self.training_dataset, self.train_input, self.train_labels = train_data
         self.validation_dataset, self.validation_input, self.validation_labels = val_data
+        self.test_dataset, self.test_input, self.test_labels = test_data
 
         # We need to actually do pretraining _after_ we've loaded the training data, though, as we
         # need to build the models to be consistent between training and pretraining.  The training
@@ -319,6 +340,13 @@ class Trainer:
         if self.save_models:
             self._save_best_model()
             self._save_auxiliary_files()
+
+        # If there are test files, we evaluate on the test data.
+        if self.test_files:
+            logger.info("Evaluting model on the test set.")
+            scores = self.model.evaluate(self.test_input, self.test_labels)
+            for idx, metric in enumerate(self.model.metrics_names):
+                print("{}: {}".format(metric, scores[idx]))
 
     def _get_callbacks(self):
         """

--- a/deep_qa/training/trainer.py
+++ b/deep_qa/training/trainer.py
@@ -78,7 +78,7 @@ class Trainer:
         self.validation_files = params.pop('validation_files', None)
 
         # The files containing the data that should be used for evaluation.
-        # The default of None mean to just not perform test set evaluation.
+        # The default of None means to just not perform test set evaluation.
         self.test_files = params.pop('test_files', None)
 
         optimizer_params = params.pop('optimizer', 'adam')

--- a/tests/common/test_case.py
+++ b/tests/common/test_case.py
@@ -16,6 +16,7 @@ class DeepQaTestCase(TestCase):
     TEST_DIR = './TMP_TEST/'
     TRAIN_FILE = TEST_DIR + 'train_file'
     VALIDATION_FILE = TEST_DIR + 'validation_file'
+    TEST_FILE = TEST_DIR + 'test_file'
     TRAIN_BACKGROUND = TEST_DIR + 'train_background'
     VALIDATION_BACKGROUND = TEST_DIR + 'validation_background'
     SNLI_FILE = TEST_DIR + 'snli_file'
@@ -83,6 +84,13 @@ class DeepQaTestCase(TestCase):
             train_file.write('4\tsentence4\t1\n')
             train_file.write('5\tsentence5\t0\n')
             train_file.write('6\tsentence6\t0\n')
+        with codecs.open(self.TEST_FILE, 'w', 'utf-8') as test_file:
+            test_file.write('1\ttestsentence1\t0\n')
+            test_file.write('2\ttestsentence2 word2 word3\t1\n')
+            test_file.write('3\ttestsentence3 word2\t0\n')
+            test_file.write('4\ttestsentence4\t1\n')
+            test_file.write('5\ttestsentence5 word4\t0\n')
+            test_file.write('6\ttestsentence6\t0\n')
 
     def write_additional_true_false_model_files(self):
         with codecs.open(self.VALIDATION_FILE, 'w', 'utf-8') as validation_file:

--- a/tests/models/multiple_choice_qa/multiple_true_false_memory_network_test.py
+++ b/tests/models/multiple_choice_qa/multiple_true_false_memory_network_test.py
@@ -28,10 +28,10 @@ class TestMultipleTrueFalseMemoryNetwork(DeepQaTestCase):
         # now fit both models on some more data, and ensure that we get the same results.
         self.write_additional_multiple_true_false_memory_network_files()
         # pylint: disable=unused-variable
-        train_data, val_data = loaded_model.prepare_data(loaded_model.train_files,
-                                                         loaded_model.max_training_instances,
-                                                         loaded_model.validation_files,
-                                                         update_data_indexer=False)
+        train_data, val_data, _ = loaded_model.prepare_data(loaded_model.train_files,
+                                                            loaded_model.max_training_instances,
+                                                            loaded_model.validation_files,
+                                                            update_data_indexer=False)
         _, train_input, train_labels = train_data
         # _, validation_input, _ = val_data
         model.model.fit(train_input, train_labels, shuffle=False, nb_epoch=1)

--- a/tests/models/reading_comprehension/bidirectional_attention_test.py
+++ b/tests/models/reading_comprehension/bidirectional_attention_test.py
@@ -28,10 +28,10 @@ class TestBidirectionalAttentionFlow(DeepQaTestCase):
         # now fit both models on some more data, and ensure that we get the same results.
         self.write_additional_span_prediction_files()
         # pylint: disable=unused-variable
-        train_data, val_data = loaded_model.prepare_data(loaded_model.train_files,
-                                                         loaded_model.max_training_instances,
-                                                         loaded_model.validation_files,
-                                                         update_data_indexer=False)
+        train_data, val_data, _ = loaded_model.prepare_data(loaded_model.train_files,
+                                                            loaded_model.max_training_instances,
+                                                            loaded_model.validation_files,
+                                                            update_data_indexer=False)
         _, train_input, train_labels = train_data
         # _, validation_input, _ = val_data
         model.model.fit(train_input, train_labels, shuffle=False, nb_epoch=1)

--- a/tests/training/text_trainer_test.py
+++ b/tests/training/text_trainer_test.py
@@ -118,6 +118,7 @@ class TestTextTrainer(DeepQaTestCase):
     def test_load_model(self):
         # train a model and serialize it.
         args = {
+                'test_files': [self.TEST_FILE],
                 'embedding_size': 4,
                 'save_models': True,
                 'tokenizer': {'type': 'words and characters'},
@@ -141,12 +142,14 @@ class TestTextTrainer(DeepQaTestCase):
         # train a model and serialize it.
         args = {
                 'embedding_size': 4,
+                'test_files': [self.TEST_FILE],
                 'save_models': True,
                 'tokenizer': {'type': 'words and characters'},
                 'show_summary_with_masking_info': True,
         }
         self.write_true_false_model_files()
         model = self.get_model(TrueFalseModel, args)
+        # train and evaluate on test set.
         model.train()
 
         # load the model that we serialized
@@ -160,10 +163,10 @@ class TestTextTrainer(DeepQaTestCase):
         # now fit both models on some more data, and ensure that we get the same results.
         self.write_additional_true_false_model_files()
         # pylint: disable=unused-variable
-        train_data, val_data = loaded_model.prepare_data(loaded_model.train_files,
-                                                         loaded_model.max_training_instances,
-                                                         loaded_model.validation_files,
-                                                         update_data_indexer=False)
+        train_data, val_data, _ = loaded_model.prepare_data(loaded_model.train_files,
+                                                            loaded_model.max_training_instances,
+                                                            loaded_model.validation_files,
+                                                            update_data_indexer=False)
         _, train_input, train_labels = train_data
         # _, validation_input, _ = val_data
         model.model.fit(train_input, train_labels, shuffle=False, nb_epoch=1)


### PR DESCRIPTION
This PR lets you pass in a `test_file` to evaluate on after training is completed.

TODO:
- [ ] Add code to the scala evaluation classes to take advantage of this parameter.
- [ ] Enable test set evaluation on the validation set epoch with the maximum validation accuracy