### PR TITLE
add BatchDot layer, tests, and docs

### DIFF
--- a/doc/api_doc/deep_qa.layers.backend.rst
+++ b/doc/api_doc/deep_qa.layers.backend.rst
@@ -4,6 +4,14 @@ deep_qa.layers.backend
 deep_qa.layers.backend.max
 --------------------------
 
+.. automodule:: deep_qa.layers.backend.batch_dot
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+deep_qa.layers.backend.max
+--------------------------
+
 .. automodule:: deep_qa.layers.backend.max
     :members:
     :undoc-members:

--- a/doc/layers/backend.rst
+++ b/doc/layers/backend.rst
@@ -4,6 +4,15 @@ Backend Layers
 Layers in this module generally just implement some simple operation from the Keras backend as a
 Layer.  The reason we have these as Layers is largely so that we can properly handle masking.
 
+BatchDot
+--------
+
+.. automodule:: deep_qa.layers.backend.batch_dot
+    :members:
+    :noindex:
+    :undoc-members:
+    :show-inheritance:
+
 Max
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@
 #### ESSENTIAL LIBRARIES FOR MAIN FUNCTIONALITY ####
 
 # Neural net and related libraries.
-# We need at least keras 1.2.0 due to the use of `keras.backend.int_shape()`
-keras>=1.2.1
+# We need at least keras 1.2.2 due to bugfixes in `keras.backend.batch_dot()`
+keras>=1.2.2
 h5py
 scikit-learn
 theano

--- a/src/main/python/deep_qa/layers/backend/batch_dot.py
+++ b/src/main/python/deep_qa/layers/backend/batch_dot.py
@@ -1,0 +1,86 @@
+import keras.backend as K
+from keras.layers import Layer
+from overrides import overrides
+
+
+class BatchDot(Layer):
+    """
+    This ``Layer`` calls ``K.batch_dot()`` on two inputs ``tensor_a`` and ``tensor_b``.
+    This function will work for tensors of arbitrary size as long as
+    ``abs(K.ndim(tensor_a) - K.ndim(tensor_b)) < 1``, due to limitations in ``K.batch_dot()``.
+
+    We always assume the dimension to perform the dot is the last one, and that
+    the masks have one fewer dimension that the tensors. Note that this layer
+    does not return zeroes in places that are masked, but does pass a correct
+    mask forward. If this then gets fed into ``masked_softmax``, for instance,
+    your tensor will be correctly normalized. We always assume the dimension to
+    perform the dot is the last one, and that the masks have one fewer
+    dimension than the tensors.
+
+    Inputs:
+        - tensor_a: tensor with ``ndim >= 2``.
+        - tensor_b: tensor with ``ndim >= 2``.
+
+    Output:
+        - a_dot_b
+
+    """
+    def __init__(self, **kwargs):
+        self.supports_masking = True
+        super(BatchDot, self).__init__(**kwargs)
+
+    @overrides
+    def compute_mask(self, inputs, mask=None):
+        # pylint: disable=unused-argument
+        tensor_a, tensor_b = inputs
+        mask_a, mask_b = mask
+        a_dot_axis = K.ndim(tensor_a) - 1
+        b_dot_axis = K.ndim(tensor_b) - 1
+
+        if K.ndim(tensor_a) < K.ndim(tensor_b):
+            # To simplify the logic below, we'll make sure that tensor_a is always the bigger one.
+            tensor_a, tensor_b = tensor_b, tensor_a
+            mask_a, mask_b = mask_b, mask_a
+
+        if mask_a is None and mask_b is None:
+            return None
+        elif mask_a is None:
+            # (batch_size, a_length)
+            mask_a = K.sum(K.ones_like(tensor_a), axis=-1)
+        elif mask_b is None:
+            # (batch_size, b_length)
+            sum_axis = -1
+            if b_dot_axis < a_dot_axis:
+                sum_axis -= 1
+            mask_b = K.sum(K.ones_like(tensor_b), axis=sum_axis)
+        # Casting masks to float since we TF would complain if we multiplied bools.
+        float_mask_a = K.cast(mask_a, 'float32')
+        float_mask_b = K.cast(mask_b, 'float32')
+
+        if b_dot_axis < a_dot_axis:
+            float_mask_b = K.expand_dims(float_mask_b, dim=-1)
+        else:
+            float_mask_a = K.expand_dims(float_mask_a, dim=-1)
+            float_mask_b = K.expand_dims(float_mask_b, dim=-2)
+        # (batch_size, a_length, b_length)
+        a2b_mask = float_mask_a * float_mask_b
+        return a2b_mask
+
+
+    @overrides
+    def get_output_shape_for(self, input_shape):
+        # This assumes that we do the dot product over the last dimension, so this
+        # will have to change if that assumption changes in masked_batch_dot.
+        a_out_shape = tuple([input_shape[0][i] for i in range(0, len(input_shape[0]) - 1)])
+        b_out_shape = tuple([input_shape[1][i] for i in range(1, len(input_shape[1]) - 1)])
+        final_out_shape = a_out_shape + b_out_shape
+        if len(final_out_shape) == 1:
+            final_out_shape += (1,)
+        return final_out_shape
+
+    @overrides
+    def call(self, x, mask=None):
+        tensor_a, tensor_b = x
+        a_dot_axis = K.ndim(tensor_a) - 1
+        b_dot_axis = K.ndim(tensor_b) - 1
+        return K.batch_dot(tensor_a, tensor_b, axes=(a_dot_axis, b_dot_axis))

--- a/src/main/python/deep_qa/layers/backend/batch_dot.py
+++ b/src/main/python/deep_qa/layers/backend/batch_dot.py
@@ -58,20 +58,20 @@ class BatchDot(Layer):
             # tensor_a has less dimensions than tensor_b.
             # We tile tensor_a to have the same shape as tensor_b
             float_mask_a = K.expand_dims(float_mask_a, dim=-1)
-            # We take the shape of mask_b as a hacky way of getting
+            # We take the shape of tensor_b as a hacky way of getting
             # around K.int_shape() and the Theano backend.
             tiled_float_mask_a = K.repeat_elements(float_mask_a,
-                                                   K.int_shape(mask_b)[-1],
+                                                   K.int_shape(tensor_b)[-2],
                                                    mask_b_dot_axis)
             final_mask = tiled_float_mask_a * float_mask_b
         else:
             # tensor_a has more dimensions than tensor_b.
             # We tile tensor_b to have the same shape as tensor_a
             float_mask_b = K.expand_dims(float_mask_b, dim=-1)
-            # We take the shape of mask_a as a hacky way of getting
+            # We take the shape of tensor_a as a hacky way of getting
             # around K.int_shape() and the Theano backend.
             tiled_float_mask_b = K.repeat_elements(float_mask_b,
-                                                   K.int_shape(mask_a)[-1],
+                                                   K.int_shape(tensor_a)[-2],
                                                    mask_a_dot_axis)
             final_mask = float_mask_a * tiled_float_mask_b
         return final_mask

--- a/src/main/python/deep_qa/layers/backend/batch_dot.py
+++ b/src/main/python/deep_qa/layers/backend/batch_dot.py
@@ -37,50 +37,84 @@ class BatchDot(Layer):
         a_dot_axis = K.ndim(tensor_a) - 1
         b_dot_axis = K.ndim(tensor_b) - 1
 
-        if K.ndim(tensor_a) < K.ndim(tensor_b):
-            # To simplify the logic below, we'll make sure that tensor_a is always the bigger one.
-            tensor_a, tensor_b = tensor_b, tensor_a
-            mask_a, mask_b = mask_b, mask_a
-
         if mask_a is None and mask_b is None:
             return None
         elif mask_a is None:
-            # (batch_size, a_length)
             mask_a = K.sum(K.ones_like(tensor_a), axis=-1)
         elif mask_b is None:
             # (batch_size, b_length)
-            sum_axis = -1
-            if b_dot_axis < a_dot_axis:
-                sum_axis -= 1
-            mask_b = K.sum(K.ones_like(tensor_b), axis=sum_axis)
-        # Casting masks to float since we TF would complain if we multiplied bools.
-        float_mask_a = K.cast(mask_a, 'float32')
-        float_mask_b = K.cast(mask_b, 'float32')
-
-        if b_dot_axis < a_dot_axis:
-            float_mask_b = K.expand_dims(float_mask_b, dim=-1)
-        else:
+            mask_b = K.sum(K.ones_like(tensor_b), axis=-1)
+        float_mask_a = K.cast(mask_a, "float32")
+        float_mask_b = K.cast(mask_b, "float32")
+        mask_a_dot_axis = K.ndim(mask_a) - 1
+        mask_b_dot_axis = K.ndim(mask_b) - 1
+        if b_dot_axis == a_dot_axis:
+            # tensor_a and tensor_b have the same length.
             float_mask_a = K.expand_dims(float_mask_a, dim=-1)
-            float_mask_b = K.expand_dims(float_mask_b, dim=-2)
-        # (batch_size, a_length, b_length)
-        a2b_mask = float_mask_a * float_mask_b
-        return a2b_mask
-
+            float_mask_b = K.expand_dims(float_mask_b, dim=-1)
+            final_mask = K.batch_dot(float_mask_a, float_mask_b,
+                                     axes=(a_dot_axis, b_dot_axis))
+        elif a_dot_axis < b_dot_axis:
+            # tensor_a has less dimensions than tensor_b.
+            # We tile tensor_a to have the same shape as tensor_b
+            float_mask_a = K.expand_dims(float_mask_a, dim=-1)
+            # We take the shape of mask_b as a hacky way of getting
+            # around K.int_shape() and the Theano backend.
+            tiled_float_mask_a = K.repeat_elements(float_mask_a,
+                                                   K.int_shape(mask_b)[-1],
+                                                   mask_b_dot_axis)
+            final_mask = tiled_float_mask_a * float_mask_b
+        else:
+            # tensor_a has more dimensions than tensor_b.
+            # We tile tensor_b to have the same shape as tensor_a
+            float_mask_b = K.expand_dims(float_mask_b, dim=-1)
+            # We take the shape of mask_a as a hacky way of getting
+            # around K.int_shape() and the Theano backend.
+            tiled_float_mask_b = K.repeat_elements(float_mask_b,
+                                                   K.int_shape(mask_a)[-1],
+                                                   mask_a_dot_axis)
+            final_mask = float_mask_a * tiled_float_mask_b
+        return final_mask
 
     @overrides
     def get_output_shape_for(self, input_shape):
-        # This assumes that we do the dot product over the last dimension, so this
-        # will have to change if that assumption changes in masked_batch_dot.
-        a_out_shape = tuple([input_shape[0][i] for i in range(0, len(input_shape[0]) - 1)])
-        b_out_shape = tuple([input_shape[1][i] for i in range(1, len(input_shape[1]) - 1)])
-        final_out_shape = a_out_shape + b_out_shape
+        tensor_a_shape, tensor_b_shape = input_shape
+        a_dot_axis = len(tensor_a_shape) - 1
+        b_dot_axis = len(tensor_b_shape) - 1
+        if b_dot_axis < a_dot_axis:
+            tensor_b_shape += (1,)
+        if b_dot_axis > a_dot_axis:
+            tensor_a_shape += (1,)
+
+        # This assumes that we do the dot product over the last dimension
+        final_out_shape = []
+        for i in range(0, len(tensor_a_shape)):
+            if i != a_dot_axis:
+                final_out_shape.append(tensor_a_shape[i])
+        for i in range(len(tensor_b_shape)-2, len(tensor_b_shape)):
+            if i != b_dot_axis and i != 0:
+                final_out_shape.append(tensor_b_shape[i])
+        if b_dot_axis != a_dot_axis:
+            # remove the 1 we inserted
+            final_out_shape.pop(a_dot_axis)
         if len(final_out_shape) == 1:
-            final_out_shape += (1,)
-        return final_out_shape
+            final_out_shape.append(1)
+        return tuple(final_out_shape)
 
     @overrides
     def call(self, x, mask=None):
         tensor_a, tensor_b = x
+        if (K.ndim(tensor_a) > 3 or K.ndim(tensor_b) > 3) and K.backend() == 'theano':
+            raise RuntimeError("K.batch_dot() in theano is broken for tensors with more than"
+                               " three dimensions.  Use tensorflow instead.")
+
         a_dot_axis = K.ndim(tensor_a) - 1
         b_dot_axis = K.ndim(tensor_b) - 1
-        return K.batch_dot(tensor_a, tensor_b, axes=(a_dot_axis, b_dot_axis))
+        if a_dot_axis > b_dot_axis:
+            tensor_b = K.expand_dims(tensor_b, dim=-1)
+        if a_dot_axis < b_dot_axis:
+            tensor_a = K.expand_dims(tensor_a, dim=-1)
+        a_dot_b = K.batch_dot(tensor_a, tensor_b, axes=(a_dot_axis, b_dot_axis))
+        if a_dot_axis != b_dot_axis:
+            a_dot_b = K.squeeze(a_dot_b, axis=a_dot_axis)
+        return a_dot_b

--- a/src/main/python/deep_qa/layers/backend/batch_dot.py
+++ b/src/main/python/deep_qa/layers/backend/batch_dot.py
@@ -8,6 +8,8 @@ class BatchDot(Layer):
     This ``Layer`` calls ``K.batch_dot()`` on two inputs ``tensor_a`` and ``tensor_b``.
     This function will work for tensors of arbitrary size as long as
     ``abs(K.ndim(tensor_a) - K.ndim(tensor_b)) < 1``, due to limitations in ``K.batch_dot()``.
+    The when the input tensors have more than three dimensions, they must have the same shape, except
+    for the last two dimensions. See the examples for more explanation of what this means.
 
     We always assume the dimension to perform the dot is the last one, and that
     the masks have one fewer dimension that the tensors. Note that this layer
@@ -23,6 +25,69 @@ class BatchDot(Layer):
 
     Output:
         - a_dot_b
+
+    Examples
+    --------
+    The following examples will try to give some insight on how this layer works in relation
+    to ``K.batch_dot()``
+
+    As a first example, let's suppose that ``tensor_a`` and ``tensor_b`` have the same number
+    of dimensions. Let the shape of ``tensor_a`` be ``(2, 3, 2)``, and let the shape of ``tensor_b`` be ``(2, 4, 2)``. The mask accompanying these inputs always has one less dimension, so the
+    ``tensor_a_mask`` has shape ``(2, 3)`` and ``tensor_b_mask`` has shape ``(2, 4)``. The shape
+    of the ``batch_dot`` output would thus be ``(2, 3, 4)``. This is because we are taking the
+    batch dot of the last dimension, so the output shape is ``(2, 3)`` (from tensor_a) with ``(4)``
+    (from tensor_b) appended on (to get ``(2, 3, 4)`` in total). The output mask has the same
+    shape as the output, and is thus ``(2, 3, 4)`` as well.
+
+    >>> import keras.backend as K
+    >>> tensor_a = K.ones(shape=(2, 3, 2))
+    >>> tensor_b = K.ones(shape=(2, 4, 2))
+    >>> K.eval(K.batch_dot(tensor_a, tensor_b, axes=(2,2))).shape
+    (2, 3, 4)
+
+    Next, let's look at an example where ``tensor_a`` and ``tensor_b`` are "uneven" (different number
+    of dimensions). Let the shape of ``tensor_a`` be ``(2, 4, 2)``, and let the shape of ``tensor_b``
+    be ``(2, 4, 3, 2)``. The mask accompanying these inputs always has one less dimension, so the
+    ``tensor_a_mask`` has shape ``(2, 4)`` and ``tensor_b_mask`` has shape ``(2, 4, 3)``. The shape
+    of the ``batch_dot`` output would thus be ``(2, 4, 3)``. In the case of uneven tensors, we always
+    expand the last dimension of the smaller tensor to make them even. Thus in this case, we expand
+    ``tensor_a`` to get a new shape of ``(2, 4, 2, 1)``. Now we are taking the ``batch_dot`` of a
+    tensor with shape ``(2, 4, 2, 1)`` and ``(2, 4, 3, 2)``. Note that the first two dimensions of
+    this tensor are the same ``(2, 4)`` -- this is an requirement imposed by ``K.batch_dot``.
+    Following the methodology of calculating the output shape above, we get that the output is
+    ``(2, 4, 1, 3)`` since we get ``(2, 4, 1)`` from ``tensor_a`` and ``(3)`` from ``tensor_b``. We
+    then squeeze the tensor to remove the 1-dimension to get a final shape of ``(2, 4, 3)``. Note
+    that the mask has the same shape.
+
+    >>> import keras.backend as K
+    >>> tensor_a = K.ones(shape=(2, 4, 2))
+    >>> tensor_b = K.ones(shape=(2, 4, 3, 2))
+    >>> tensor_a_expanded = K.expand_dims(tensor_a, dim=-1)
+    >>> unsqueezed_bd = K.batch_dot(tensor_a_expanded, tensor_b, axes=(2,3))
+    >>> final_bd = K.squeeze(unsqueezed_bd, axis=K.ndim(tensor_a)-1)
+    >>> K.eval(final_bd).shape
+    (2, 4, 3)
+
+    Lastly, let's look at the uneven case where ``tensor_a`` has more dimensions than ``tensor_b``.
+    Let the shape of ``tensor_a`` be ``(2, 3, 4, 2)``, and let the shape of ``tensor_b``
+    be ``(2, 3, 2)``. Since the mask accompanying these inputs always has one less dimension,
+    ``tensor_a_mask`` has shape ``(2, 3, 4)`` and ``tensor_b_mask`` has shape ``(2, 3)``. The shape
+    of the ``batch_dot`` output would thus be ``(2, 3, 4)``. Since these tensors are uneven, expand
+    the smaller tensor, ``tensor_b``, to get a new shape of ``(2, 3, 2, 1)``. Now we are taking
+    the ``batch_dot`` of a tensor with shape ``(2, 3, 4, 2)`` and ``(2, 3, 2, 1)``. Note again that the
+    first two dimensions of this tensor are the same ``(2, 3)``. We can see that the output shape is
+    ``(2, 3, 4, 1)`` since we get ``(2, 3, 4)`` from ``tensor_a`` and ``(1)`` from ``tensor_b``. We
+    then squeeze the tensor to remove the 1-dimension to get a final shape of ``(2, 3, 4)``. Note
+    that the mask has the same shape.
+
+    >>> import keras.backend as K
+    >>> tensor_a = K.ones(shape=(2, 3, 4, 2))
+    >>> tensor_b = K.ones(shape=(2, 3, 2))
+    >>> tensor_b_expanded = K.expand_dims(tensor_b, dim=-1)
+    >>> unsqueezed_bd = K.batch_dot(tensor_a, tensor_b_expanded, axes=(3, 2))
+    >>> final_bd = K.squeeze(unsqueezed_bd, axis=K.ndim(tensor_a)-1)
+    >>> K.eval(final_bd).shape
+    (2, 3, 4)
 
     """
     def __init__(self, **kwargs):

--- a/src/main/python/deep_qa/layers/backend/batch_dot.py
+++ b/src/main/python/deep_qa/layers/backend/batch_dot.py
@@ -8,7 +8,7 @@ class BatchDot(Layer):
     This ``Layer`` calls ``K.batch_dot()`` on two inputs ``tensor_a`` and ``tensor_b``.
     This function will work for tensors of arbitrary size as long as
     ``abs(K.ndim(tensor_a) - K.ndim(tensor_b)) < 1``, due to limitations in ``K.batch_dot()``.
-    The when the input tensors have more than three dimensions, they must have the same shape, except
+    When the input tensors have more than three dimensions, they must have the same shape, except
     for the last two dimensions. See the examples for more explanation of what this means.
 
     We always assume the dimension to perform the dot is the last one, and that
@@ -29,15 +29,17 @@ class BatchDot(Layer):
     Examples
     --------
     The following examples will try to give some insight on how this layer works in relation
-    to ``K.batch_dot()``
+    to ``K.batch_dot()``. Note that the Keras documentation (as of 2/13/17) on ``K.batch_dot``
+    is incorrect, and that this layer behaves differently from the documented behavior.
 
-    As a first example, let's suppose that ``tensor_a`` and ``tensor_b`` have the same number
-    of dimensions. Let the shape of ``tensor_a`` be ``(2, 3, 2)``, and let the shape of ``tensor_b`` be ``(2, 4, 2)``. The mask accompanying these inputs always has one less dimension, so the
-    ``tensor_a_mask`` has shape ``(2, 3)`` and ``tensor_b_mask`` has shape ``(2, 4)``. The shape
-    of the ``batch_dot`` output would thus be ``(2, 3, 4)``. This is because we are taking the
-    batch dot of the last dimension, so the output shape is ``(2, 3)`` (from tensor_a) with ``(4)``
-    (from tensor_b) appended on (to get ``(2, 3, 4)`` in total). The output mask has the same
-    shape as the output, and is thus ``(2, 3, 4)`` as well.
+    As a first example, let's suppose that ``tensor_a`` and ``tensor_b`` have the same
+    number of dimensions. Let the shape of ``tensor_a`` be ``(2, 3, 2)``, and let the shape
+    of ``tensor_b`` be ``(2, 4, 2)``. The mask accompanying these inputs always has one less
+    dimension, so the ``tensor_a_mask`` has shape ``(2, 3)`` and ``tensor_b_mask`` has
+    shape ``(2, 4)``. The shape of the ``batch_dot`` output would thus be ``(2, 3, 4)``. This is
+    because we are taking the batch dot of the last dimension, so the output shape is ``(2, 3)``
+    (from tensor_a) with ``(4)`` (from tensor_b) appended on (to get ``(2, 3, 4)`` in total). The
+    output mask has the same shape as the output, and is thus ``(2, 3, 4)`` as well.
 
     >>> import keras.backend as K
     >>> tensor_a = K.ones(shape=(2, 3, 2))
@@ -53,7 +55,7 @@ class BatchDot(Layer):
     expand the last dimension of the smaller tensor to make them even. Thus in this case, we expand
     ``tensor_a`` to get a new shape of ``(2, 4, 2, 1)``. Now we are taking the ``batch_dot`` of a
     tensor with shape ``(2, 4, 2, 1)`` and ``(2, 4, 3, 2)``. Note that the first two dimensions of
-    this tensor are the same ``(2, 4)`` -- this is an requirement imposed by ``K.batch_dot``.
+    this tensor are the same ``(2, 4)`` -- this is a requirement imposed by ``K.batch_dot``.
     Following the methodology of calculating the output shape above, we get that the output is
     ``(2, 4, 1, 3)`` since we get ``(2, 4, 1)`` from ``tensor_a`` and ``(3)`` from ``tensor_b``. We
     then squeeze the tensor to remove the 1-dimension to get a final shape of ``(2, 4, 3)``. Note

--- a/src/test/python/deep_qa_test/layers/backend/batch_dot_test.py
+++ b/src/test/python/deep_qa_test/layers/backend/batch_dot_test.py
@@ -1,19 +1,26 @@
 # pylint: disable=no-self-use,invalid-name
+from unittest import TestCase
 import numpy
 from numpy.testing import assert_almost_equal
 import keras.backend as K
+from keras.layers import Input, Masking
+from keras.models import Model
 
 from deep_qa.layers.backend.batch_dot import BatchDot
+from deep_qa.layers.wrappers import OutputMask
 
 
-class TestMaskedBatchDotLayer:
-    def test_compute_mask(self):
-        tensor_a = K.variable(numpy.array([[[0.3, 0.1], [0.4, 0.2], [0.8, 0.1]],
-                                           [[0.3, 0.1], [0.4, 0.2], [0.8, 0.1]]]))
+class TestBatchDotLayer(TestCase):
+    def test_compute_mask_basic(self):
+        batch_size = 2
+        # test the case where the tensors are even
+        # tensor_a has shape (2, 3, 2), so mask_a has shape (2, 3)
+        tensor_a = K.variable(numpy.random.randint(7, size=(batch_size, 3, 2)))
         mask_a = K.variable(numpy.array([[1, 0, 1], [1, 1, 0]]))
-        tensor_b = K.variable(numpy.array([[[0.2, 0.6], [0.4, 0.3], [0.5, 0.7], [0.1, .6]],
-                                           [[0.2, 0.6], [0.4, 0.3], [0.5, 0.7], [0.1, .6]]]))
+        # tensor_b has shape (2, 4, 2), so mask_b has shape (2, 4)
+        tensor_b = K.variable(numpy.random.randint(7, size=(batch_size, 4, 2)))
         mask_b = K.variable(numpy.array([[0, 1, 1, 1], [1, 0, 1, 1]]))
+        # a_dot_b would have shape (2, 3, 4), so mask of a_dot_b has shape (2, 3, 4)
         calculated_mask = K.eval(BatchDot().compute_mask([tensor_a, tensor_b],
                                                          [mask_a, mask_b]))
         assert_almost_equal(calculated_mask, numpy.array([[[0.0, 1.0, 1.0, 1.0],
@@ -23,10 +30,155 @@ class TestMaskedBatchDotLayer:
                                                            [1.0, 0.0, 1.0, 1.0],
                                                            [0.0, 0.0, 0.0, 0.0]]]))
 
-    def test_get_output_shape_for(self):
+        # test the case where tensor_a has less dimensions than tensor_b
+        # tensor_a has shape (2, 4, 2), so mask_a has shape (2, 4)
+        tensor_a = K.variable(numpy.random.randint(7, size=(batch_size, 4, 2)))
+        mask_a = K.variable(numpy.array([[1, 0, 1, 0], [1, 1, 0, 0]]))
+        # tensor_b has shape (2, 4, 3, 2), so mask_b has shape (2, 4, 3)
+        tensor_b = K.variable(numpy.random.randint(7, size=(batch_size, 4, 3, 2)))
+        mask_b = K.variable(numpy.array([[[1, 1, 1],
+                                          [1, 1, 1],
+                                          [1, 1, 0],
+                                          [1, 0, 0]],
+                                         [[1, 1, 1],
+                                          [1, 1, 0],
+                                          [1, 0, 0],
+                                          [0, 0, 0]]]))
+        # a_dot_b would have shape (2, 4, 3), so mask of a_dot_b has shape (2, 4, 3)
+        calculated_mask = K.eval(BatchDot().compute_mask([tensor_a, tensor_b],
+                                                         [mask_a, mask_b]))
+        assert calculated_mask.shape == (batch_size, 4, 3)
+        assert_almost_equal(calculated_mask, numpy.array([[[1.0, 1.0, 1.0],
+                                                           [0.0, 0.0, 0.0],
+                                                           [1.0, 1.0, 0.0],
+                                                           [0.0, 0.0, 0.0]],
+                                                          [[1.0, 1.0, 1.0],
+                                                           [1.0, 1.0, 0.0],
+                                                           [0.0, 0.0, 0.0],
+                                                           [0.0, 0.0, 0.0]]]))
+
+        # test the case where tensor_a has more dimensions than tensor_b
+        # tensor_a has shape (2, 3, 4, 2), so mask_a has shape (2, 3, 4)
+        tensor_a = K.variable(numpy.random.randint(7, size=(batch_size, 3, 4, 2)))
+        mask_a = K.variable(numpy.array([[[1, 1, 1, 1],
+                                          [1, 1, 1, 1],
+                                          [1, 1, 0, 1]],
+                                         [[1, 1, 1, 1],
+                                          [1, 1, 0, 1],
+                                          [1, 0, 0, 1]]]))
+        # tensor_b has shape (2, 3, 2), so mask_b has shape (2, 3)
+        tensor_b = K.variable(numpy.random.randint(7, size=(batch_size, 3, 2)))
+        mask_b = K.variable(numpy.array([[1, 0, 1], [1, 1, 0]]))
+        # a_dot_b would have shape (2, 3, 4), so mask of a_dot_b has shape (2, 3, 4)
+        calculated_mask = K.eval(BatchDot().compute_mask([tensor_a, tensor_b],
+                                                         [mask_a, mask_b]))
+        assert calculated_mask.shape == (batch_size, 3, 4)
+        assert_almost_equal(calculated_mask, numpy.array([[[1.0, 1.0, 1.0, 1.0],
+                                                           [0.0, 0.0, 0.0, 0.0],
+                                                           [1.0, 1.0, 0.0, 1.0]],
+                                                          [[1.0, 1.0, 1.0, 1.0],
+                                                           [1.0, 1.0, 0.0, 1.0],
+                                                           [0.0, 0.0, 0.0, 0.0]]]))
+
+    def test_compute_mask_a_smaller_than_b_higher_dimension(self):
+        batch_size = 3
+        tensor_a = numpy.random.randint(7, size=(batch_size, 4, 5))
+        tensor_b = numpy.random.randint(7, size=(batch_size, 4, 2, 5))
+
+        # Manually set some values to 1 here, which will be masked later
+        # (1 and not 0 so that masked values are still non-zero in the output)
+        tensor_a[0][1] = 0
+        tensor_a[1][3] = 0
+        tensor_b[0][1][1] = 0
+        tensor_b[0][2][1] = 0
+
+        input_tensor_a = Input(shape=(4, 5))
+        masked_tensor_a = Masking(mask_value=0)(input_tensor_a)
+        input_tensor_b = Input(shape=(4, 2, 5))
+        masked_tensor_b = Masking(mask_value=0)(input_tensor_b)
+
+        if K.backend() == "theano":
+            self.assertRaises(RuntimeError, BatchDot(),
+                              [masked_tensor_a, masked_tensor_b])
+            return
+        else:
+            a_dot_b = BatchDot()([masked_tensor_a, masked_tensor_b])
+
+        a_dot_b_mask = OutputMask()(a_dot_b)
+        model = Model(input=[input_tensor_a, input_tensor_b],
+                      output=[a_dot_b, a_dot_b_mask])
+        # a_dot_b and mask_tensor are of shape (3, 4, 2).
+        if K.backend() == "theano":
+            self.assertRaises(RuntimeError, model.predict,
+                              [tensor_a, tensor_b])
+            return
+        else:
+            a_dot_b_tensor, mask_tensor = model.predict([tensor_a, tensor_b])
+        # Test that the dot happened like we expected.
+        for i in range(batch_size):
+            # each dot product should be of shape (4, 2)
+            assert_almost_equal(a_dot_b_tensor[i],
+                                numpy.einsum("ij,imj->im", tensor_a[i], tensor_b[i]))
+        # Check that the values in the output mask are 0 where the
+        # values were set to 1 above.
+        assert mask_tensor[0][1][0] == 0
+        assert mask_tensor[0][1][1] == 0
+        assert mask_tensor[0][2][1] == 0
+        assert mask_tensor[1][3][0] == 0
+        assert mask_tensor[1][3][1] == 0
+
+    def test_compute_mask_a_larger_than_b_higher_dimension(self):
+        batch_size = 3
+        tensor_a = numpy.random.randint(7, size=(batch_size, 4, 2, 5))
+        tensor_b = numpy.random.randint(7, size=(batch_size, 4, 5))
+
+        # Manually set some values to 1 here, which will be masked later
+        # (1 and not 0 so that masked values are still non-zero in the output)
+        tensor_a[0][1][1] = 0
+        tensor_a[0][2][1] = 0
+        tensor_b[0][1] = 0
+        tensor_b[1][3] = 0
+
+        input_tensor_a = Input(shape=(4, 2, 5))
+        masked_tensor_a = Masking(mask_value=0)(input_tensor_a)
+        input_tensor_b = Input(shape=(4, 5))
+        masked_tensor_b = Masking(mask_value=0)(input_tensor_b)
+
+        if K.backend() == "theano":
+            self.assertRaises(RuntimeError, BatchDot(),
+                              [masked_tensor_a, masked_tensor_b])
+            return
+        else:
+            a_dot_b = BatchDot()([masked_tensor_a, masked_tensor_b])
+        a_dot_b_mask = OutputMask()(a_dot_b)
+        model = Model(input=[input_tensor_a, input_tensor_b],
+                      output=[a_dot_b, a_dot_b_mask])
+        # a_dot_b and mask_tensor are of shape (3, 4, 2).
+        a_dot_b_tensor, mask_tensor = model.predict([tensor_a, tensor_b])
+        # Test that the dot happened like we expected.
+        for i in range(batch_size):
+            # each dot product should be of shape (4, 2)
+            assert_almost_equal(a_dot_b_tensor[i],
+                                numpy.einsum("imj,ij->im", tensor_a[i], tensor_b[i]))
+            # Check that the values in the output mask are 0 where the
+            # values were set to 1 above.
+        assert mask_tensor[0][1][0] == 0
+        assert mask_tensor[0][1][1] == 0
+        assert mask_tensor[0][2][1] == 0
+        assert mask_tensor[1][3][0] == 0
+        assert mask_tensor[1][3][1] == 0
+
+    def test_output_shapes(self):
         mbd = BatchDot()
-        assert mbd.get_output_shape_for([(5, 10), (5, 10)]) == (5, 1)
-        assert mbd.get_output_shape_for([(1, 1, 1), (1, 1, 1)]) == (1, 1, 1)
-        assert mbd.get_output_shape_for([(1, 5, 3), (1, 2, 3)]) == (1, 5, 2)
-        assert mbd.get_output_shape_for([(1, 5, 4, 3), (1, 2, 3)]) == (1, 5, 4, 2)
-        assert mbd.get_output_shape_for([(1, 5, 4), (1, 2, 3, 4)]) == (1, 5, 2, 3)
+        a_shapes = [(5, 10), (1, 1, 1), (1, 5, 3), (1, 5, 4, 3), (1, 5, 3)]
+        b_shapes = [(5, 10), (1, 1, 1), (1, 2, 3), (1, 5, 3), (1, 5, 4, 3)]
+        expected_shapes = [(5, 1), (1, 1, 1), (1, 5, 2), (1, 5, 4), (1, 5, 4)]
+        for a_shape, b_shape, expected_shape in zip(a_shapes, b_shapes, expected_shapes):
+            if (len(a_shape) > 3 or len(b_shape) > 3) and K.backend() == "theano":
+                # this breaks in theano, so check that an error is raised
+                self.assertRaises(RuntimeError, mbd.call,
+                                  [K.ones(shape=a_shape), K.ones(shape=b_shape)])
+                # assert K.eval(mbd([K.ones(shape=a_shape), K.ones(shape=b_shape)])).shape == expected_shape
+            else:
+                assert K.eval(mbd([K.ones(shape=a_shape), K.ones(shape=b_shape)])).shape == expected_shape
+            assert mbd.get_output_shape_for([a_shape, b_shape]) == expected_shape

--- a/src/test/python/deep_qa_test/layers/backend/batch_dot_test.py
+++ b/src/test/python/deep_qa_test/layers/backend/batch_dot_test.py
@@ -80,7 +80,7 @@ class TestBatchDotLayer(TestCase):
                                                            [1.0, 1.0, 0.0, 1.0],
                                                            [0.0, 0.0, 0.0, 0.0]]]))
 
-    def test_compute_mask_a_smaller_than_b(self):
+    def test_a_smaller_than_b(self):
         batch_size = 3
         tensor_a = numpy.random.randint(7, size=(batch_size, 5))
         tensor_b = numpy.random.randint(7, size=(batch_size, 2, 5))
@@ -112,7 +112,7 @@ class TestBatchDotLayer(TestCase):
         assert mask_tensor[0][0] == 0
         assert mask_tensor[0][1] == 0
 
-    def test_compute_mask_a_larger_than_b(self):
+    def test_a_larger_than_b(self):
         batch_size = 3
         tensor_a = numpy.random.randint(7, size=(batch_size, 2, 5))
         tensor_b = numpy.random.randint(7, size=(batch_size, 5))
@@ -144,7 +144,7 @@ class TestBatchDotLayer(TestCase):
         assert mask_tensor[0][0] == 0
         assert mask_tensor[0][1] == 0
 
-    def test_compute_mask_a_smaller_than_b_higher_dimension(self):
+    def test_a_smaller_than_b_higher_dimension(self):
         batch_size = 3
         tensor_a = numpy.random.randint(7, size=(batch_size, 4, 5))
         tensor_b = numpy.random.randint(7, size=(batch_size, 4, 2, 5))
@@ -186,7 +186,7 @@ class TestBatchDotLayer(TestCase):
         assert mask_tensor[1][3][0] == 0
         assert mask_tensor[1][3][1] == 0
 
-    def test_compute_mask_a_larger_than_b_higher_dimension(self):
+    def test_a_larger_than_b_higher_dimension(self):
         batch_size = 3
         tensor_a = numpy.random.randint(7, size=(batch_size, 4, 2, 5))
         tensor_b = numpy.random.randint(7, size=(batch_size, 4, 5))
@@ -228,15 +228,15 @@ class TestBatchDotLayer(TestCase):
         assert mask_tensor[1][3][1] == 0
 
     def test_output_shapes(self):
-        mbd = BatchDot()
+        bd = BatchDot()
         a_shapes = [(5, 10), (1, 1, 1), (1, 5, 3), (1, 5, 4, 3), (1, 5, 3)]
         b_shapes = [(5, 10), (1, 1, 1), (1, 2, 3), (1, 5, 3), (1, 5, 4, 3)]
         expected_shapes = [(5, 1), (1, 1, 1), (1, 5, 2), (1, 5, 4), (1, 5, 4)]
         for a_shape, b_shape, expected_shape in zip(a_shapes, b_shapes, expected_shapes):
             if (len(a_shape) > 3 or len(b_shape) > 3) and K.backend() == "theano":
                 # this breaks in theano, so check that an error is raised
-                self.assertRaises(RuntimeError, mbd.call,
+                self.assertRaises(RuntimeError, bd.call,
                                   [K.ones(shape=a_shape), K.ones(shape=b_shape)])
             else:
-                assert K.eval(mbd([K.ones(shape=a_shape), K.ones(shape=b_shape)])).shape == expected_shape
-            assert mbd.get_output_shape_for([a_shape, b_shape]) == expected_shape
+                assert K.eval(bd([K.ones(shape=a_shape), K.ones(shape=b_shape)])).shape == expected_shape
+            assert bd.get_output_shape_for([a_shape, b_shape]) == expected_shape

--- a/src/test/python/deep_qa_test/layers/backend/batch_dot_test.py
+++ b/src/test/python/deep_qa_test/layers/backend/batch_dot_test.py
@@ -80,6 +80,70 @@ class TestBatchDotLayer(TestCase):
                                                            [1.0, 1.0, 0.0, 1.0],
                                                            [0.0, 0.0, 0.0, 0.0]]]))
 
+    def test_compute_mask_a_smaller_than_b(self):
+        batch_size = 3
+        tensor_a = numpy.random.randint(7, size=(batch_size, 5))
+        tensor_b = numpy.random.randint(7, size=(batch_size, 2, 5))
+
+        # Manually set some values to 1 here, which will be masked later
+        # (1 and not 0 so that masked values are still non-zero in the output)
+        tensor_a[0] = 0
+        tensor_b[0][1] = 0
+
+        input_tensor_a = Input(shape=(5,))
+        masked_tensor_a = Masking(mask_value=0)(input_tensor_a)
+        input_tensor_b = Input(shape=(2, 5))
+        masked_tensor_b = Masking(mask_value=0)(input_tensor_b)
+
+        a_dot_b = BatchDot()([masked_tensor_a, masked_tensor_b])
+
+        a_dot_b_mask = OutputMask()(a_dot_b)
+        model = Model(input=[input_tensor_a, input_tensor_b],
+                      output=[a_dot_b, a_dot_b_mask])
+        # a_dot_b and mask_tensor are of shape (3, 2).
+        a_dot_b_tensor, mask_tensor = model.predict([tensor_a, tensor_b])
+        # Test that the dot happened like we expected.
+        for i in range(batch_size):
+            # each dot product should be of shape (2,)
+            assert_almost_equal(a_dot_b_tensor[i],
+                                numpy.einsum("i,mi->m", tensor_a[i], tensor_b[i]))
+        # Check that the values in the output mask are 0 where the
+        # values were set to 1 above.
+        assert mask_tensor[0][0] == 0
+        assert mask_tensor[0][1] == 0
+
+    def test_compute_mask_a_larger_than_b(self):
+        batch_size = 3
+        tensor_a = numpy.random.randint(7, size=(batch_size, 2, 5))
+        tensor_b = numpy.random.randint(7, size=(batch_size, 5))
+
+        # Manually set some values to 1 here, which will be masked later
+        # (1 and not 0 so that masked values are still non-zero in the output)
+        tensor_a[0][1] = 0
+        tensor_b[0] = 0
+
+        input_tensor_a = Input(shape=(2, 5))
+        masked_tensor_a = Masking(mask_value=0)(input_tensor_a)
+        input_tensor_b = Input(shape=(5,))
+        masked_tensor_b = Masking(mask_value=0)(input_tensor_b)
+
+        a_dot_b = BatchDot()([masked_tensor_a, masked_tensor_b])
+
+        a_dot_b_mask = OutputMask()(a_dot_b)
+        model = Model(input=[input_tensor_a, input_tensor_b],
+                      output=[a_dot_b, a_dot_b_mask])
+        # a_dot_b and mask_tensor are of shape (3, 2).
+        a_dot_b_tensor, mask_tensor = model.predict([tensor_a, tensor_b])
+        # Test that the dot happened like we expected.
+        for i in range(batch_size):
+            # each dot product should be of shape (2,)
+            assert_almost_equal(a_dot_b_tensor[i],
+                                numpy.einsum("mi,i->m", tensor_a[i], tensor_b[i]))
+        # Check that the values in the output mask are 0 where the
+        # values were set to 1 above.
+        assert mask_tensor[0][0] == 0
+        assert mask_tensor[0][1] == 0
+
     def test_compute_mask_a_smaller_than_b_higher_dimension(self):
         batch_size = 3
         tensor_a = numpy.random.randint(7, size=(batch_size, 4, 5))
@@ -108,12 +172,7 @@ class TestBatchDotLayer(TestCase):
         model = Model(input=[input_tensor_a, input_tensor_b],
                       output=[a_dot_b, a_dot_b_mask])
         # a_dot_b and mask_tensor are of shape (3, 4, 2).
-        if K.backend() == "theano":
-            self.assertRaises(RuntimeError, model.predict,
-                              [tensor_a, tensor_b])
-            return
-        else:
-            a_dot_b_tensor, mask_tensor = model.predict([tensor_a, tensor_b])
+        a_dot_b_tensor, mask_tensor = model.predict([tensor_a, tensor_b])
         # Test that the dot happened like we expected.
         for i in range(batch_size):
             # each dot product should be of shape (4, 2)
@@ -178,7 +237,6 @@ class TestBatchDotLayer(TestCase):
                 # this breaks in theano, so check that an error is raised
                 self.assertRaises(RuntimeError, mbd.call,
                                   [K.ones(shape=a_shape), K.ones(shape=b_shape)])
-                # assert K.eval(mbd([K.ones(shape=a_shape), K.ones(shape=b_shape)])).shape == expected_shape
             else:
                 assert K.eval(mbd([K.ones(shape=a_shape), K.ones(shape=b_shape)])).shape == expected_shape
             assert mbd.get_output_shape_for([a_shape, b_shape]) == expected_shape

--- a/src/test/python/deep_qa_test/layers/backend/batch_dot_test.py
+++ b/src/test/python/deep_qa_test/layers/backend/batch_dot_test.py
@@ -1,0 +1,32 @@
+# pylint: disable=no-self-use,invalid-name
+import numpy
+from numpy.testing import assert_almost_equal
+import keras.backend as K
+
+from deep_qa.layers.backend.batch_dot import BatchDot
+
+
+class TestMaskedBatchDotLayer:
+    def test_compute_mask(self):
+        tensor_a = K.variable(numpy.array([[[0.3, 0.1], [0.4, 0.2], [0.8, 0.1]],
+                                           [[0.3, 0.1], [0.4, 0.2], [0.8, 0.1]]]))
+        mask_a = K.variable(numpy.array([[1, 0, 1], [1, 1, 0]]))
+        tensor_b = K.variable(numpy.array([[[0.2, 0.6], [0.4, 0.3], [0.5, 0.7], [0.1, .6]],
+                                           [[0.2, 0.6], [0.4, 0.3], [0.5, 0.7], [0.1, .6]]]))
+        mask_b = K.variable(numpy.array([[0, 1, 1, 1], [1, 0, 1, 1]]))
+        calculated_mask = K.eval(BatchDot().compute_mask([tensor_a, tensor_b],
+                                                         [mask_a, mask_b]))
+        assert_almost_equal(calculated_mask, numpy.array([[[0.0, 1.0, 1.0, 1.0],
+                                                           [0.0, 0.0, 0.0, 0.0],
+                                                           [0.0, 1.0, 1.0, 1.0]],
+                                                          [[1.0, 0.0, 1.0, 1.0],
+                                                           [1.0, 0.0, 1.0, 1.0],
+                                                           [0.0, 0.0, 0.0, 0.0]]]))
+
+    def test_get_output_shape_for(self):
+        mbd = BatchDot()
+        assert mbd.get_output_shape_for([(5, 10), (5, 10)]) == (5, 1)
+        assert mbd.get_output_shape_for([(1, 1, 1), (1, 1, 1)]) == (1, 1, 1)
+        assert mbd.get_output_shape_for([(1, 5, 3), (1, 2, 3)]) == (1, 5, 2)
+        assert mbd.get_output_shape_for([(1, 5, 4, 3), (1, 2, 3)]) == (1, 5, 4, 2)
+        assert mbd.get_output_shape_for([(1, 5, 4), (1, 2, 3, 4)]) == (1, 5, 2, 3)


### PR DESCRIPTION
this PR adds a `BatchDot` layer that simply takes the output of `K.batch_dot` and propagates a correct mask with it. I didn't bother testing the call function because I'm presuming `K.batch_dot` is well tested :)