### PR TITLE
casting mask to float32

### DIFF
--- a/deep_qa/layers/noisy_or.py
+++ b/deep_qa/layers/noisy_or.py
@@ -84,7 +84,7 @@ class NoisyOr(Layer):
         # shape: (batch size, ..., num_probs, ...)
         probabilities = inputs
         if mask is not None:
-            probabilities *= mask
+            probabilities *= K.cast(mask, "float32")
 
         noisy_probs = self.noise_parameter * probabilities
 


### PR DESCRIPTION
necessary for running the real model which has a mask of dtype=uint8 