### PR TITLE
Rename max_length dictionary members

### DIFF
--- a/deep_qa/contrib/span_prediction/span_model.py
+++ b/deep_qa/contrib/span_prediction/span_model.py
@@ -20,15 +20,15 @@ from loaders import  load_parses, read_barrons, get_science_terms # pylint: disa
 
 
 # constrained legal span lengths. Upper diagonal band in begin vs. end matrix.
-def legal_spans(max_sentence_length, max_span_length):
-    for span in product(range(0, max_sentence_length), range(0, max_sentence_length)):
+def legal_spans(num_sentence_words, max_span_length):
+    for span in product(range(0, num_sentence_words), range(0, num_sentence_words)):
         if span[0] >= span[1] or span[1] - span[0] > max_span_length:
             continue
         yield span
 
 
 def create_training_examples(statement_list: List[List[str]], trees, training_spans,
-                             training: bool, max_span_length, max_sentence_length,
+                             training: bool, max_span_length, num_sentence_words,
                              args, pos_tags, constituents, k=1):
     """
     This function defines a training set for span prediction.
@@ -66,7 +66,7 @@ def create_training_examples(statement_list: List[List[str]], trees, training_sp
         sentence_candidate_span_examples = []   # when training.
 
         # loop across different spans for given sentence
-        for span in legal_spans(max_sentence_length, max_span_length):  #globally legal
+        for span in legal_spans(num_sentence_words, max_span_length):  #globally legal
             if span[1] > len(statement):
                 continue
             if span[0] > len(statement):
@@ -260,7 +260,7 @@ def main():
 
     # general characteristics of sentences/ spans
     max_span_length = max([span[1]-span[0] for span in training_spans])     #11
-    max_sentence_length = max([len(stmnt) for stmnt in training_statements])    #46
+    num_sentence_words = max([len(stmnt) for stmnt in training_statements])    #46
 
 
 
@@ -283,7 +283,7 @@ def main():
     all_examples, all_labels, examples_per_sentence, _ = \
                     create_training_examples(training_statements, training_trees,
                                              training_spans, True,
-                                             max_span_length, max_sentence_length,
+                                             max_span_length, num_sentence_words,
                                              args, pos_tags, constituents)
 
 
@@ -430,7 +430,7 @@ def main():
         # compute features for barron's
         _, _, barron_span_features, span_indexes = \
         create_training_examples(barron_statements, barron_trees, False, False,
-                                 max_span_length, max_sentence_length, args, pos_tags,
+                                 max_span_length, num_sentence_words, args, pos_tags,
                                  constituents)
 
 

--- a/deep_qa/data/instances/instance.py
+++ b/deep_qa/data/instances/instance.py
@@ -230,18 +230,18 @@ class IndexedInstance(Instance):
         raise NotImplementedError
 
     @staticmethod
-    def _get_word_sequence_lengths(word_indices: List) -> Dict[str, int]:
+    def _get_max_sentence_lengths(word_indices: List) -> Dict[str, int]:
         """
         Because ``TextEncoders`` can return complex data structures, we might
         actually have several things to pad for a single word sequence. We
         check for that and handle it in a single spot here. We return a
-        dictionary containing 'word_sequence_length', which is the number of
+        dictionary containing 'max_sentence_length', which is the number of
         words in word_indices. If the word representations also contain
         characters, the dictionary additionally contains a
         'word_character_length' key, with a value corresponding to the longest
         word in the sequence.
         """
-        lengths = {'word_sequence_length': len(word_indices)}
+        lengths = {'max_sentence_length': len(word_indices)}
         if len(word_indices) > 0 and not isinstance(word_indices[0], int):
             if isinstance(word_indices[0], list):
                 lengths['word_character_length'] = max([len(word) for word in word_indices])
@@ -289,7 +289,7 @@ class IndexedInstance(Instance):
             default_value = lambda: []
 
         padded_word_sequence = IndexedInstance.pad_sequence_to_length(
-                word_sequence, lengths['word_sequence_length'], default_value, truncate_from_right)
+                word_sequence, lengths['max_sentence_length'], default_value, truncate_from_right)
         if 'word_character_length' in lengths:
             padded_word_sequence = [IndexedInstance.pad_sequence_to_length(
                     word, lengths['word_character_length'], truncate_from_right=False)

--- a/deep_qa/data/instances/instance.py
+++ b/deep_qa/data/instances/instance.py
@@ -230,7 +230,7 @@ class IndexedInstance(Instance):
         raise NotImplementedError
 
     @staticmethod
-    def _get_word_sequence_lengthss(word_indices: List) -> Dict[str, int]:
+    def _get_word_sequence_lengths(word_indices: List) -> Dict[str, int]:
         """
         Because ``TextEncoders`` can return complex data structures, we might
         actually have several things to pad for a single word sequence. We

--- a/deep_qa/data/instances/instance.py
+++ b/deep_qa/data/instances/instance.py
@@ -230,18 +230,18 @@ class IndexedInstance(Instance):
         raise NotImplementedError
 
     @staticmethod
-    def _get_max_sentence_lengths(word_indices: List) -> Dict[str, int]:
+    def _get_num_sentence_wordss(word_indices: List) -> Dict[str, int]:
         """
         Because ``TextEncoders`` can return complex data structures, we might
         actually have several things to pad for a single word sequence. We
         check for that and handle it in a single spot here. We return a
-        dictionary containing 'max_sentence_length', which is the number of
+        dictionary containing 'num_sentence_words', which is the number of
         words in word_indices. If the word representations also contain
         characters, the dictionary additionally contains a
         'max_word_length' key, with a value corresponding to the longest
         word in the sequence.
         """
-        lengths = {'max_sentence_length': len(word_indices)}
+        lengths = {'num_sentence_words': len(word_indices)}
         if len(word_indices) > 0 and not isinstance(word_indices[0], int):
             if isinstance(word_indices[0], list):
                 lengths['max_word_length'] = max([len(word) for word in word_indices])
@@ -289,7 +289,7 @@ class IndexedInstance(Instance):
             default_value = lambda: []
 
         padded_word_sequence = IndexedInstance.pad_sequence_to_length(
-                word_sequence, lengths['max_sentence_length'], default_value, truncate_from_right)
+                word_sequence, lengths['num_sentence_words'], default_value, truncate_from_right)
         if 'max_word_length' in lengths:
             padded_word_sequence = [IndexedInstance.pad_sequence_to_length(
                     word, lengths['max_word_length'], truncate_from_right=False)

--- a/deep_qa/data/instances/instance.py
+++ b/deep_qa/data/instances/instance.py
@@ -230,7 +230,7 @@ class IndexedInstance(Instance):
         raise NotImplementedError
 
     @staticmethod
-    def _get_num_sentence_wordss(word_indices: List) -> Dict[str, int]:
+    def _get_word_sequence_lengthss(word_indices: List) -> Dict[str, int]:
         """
         Because ``TextEncoders`` can return complex data structures, we might
         actually have several things to pad for a single word sequence. We

--- a/deep_qa/data/instances/instance.py
+++ b/deep_qa/data/instances/instance.py
@@ -238,13 +238,13 @@ class IndexedInstance(Instance):
         dictionary containing 'num_sentence_words', which is the number of
         words in word_indices. If the word representations also contain
         characters, the dictionary additionally contains a
-        'max_word_length' key, with a value corresponding to the longest
+        'num_word_characters' key, with a value corresponding to the longest
         word in the sequence.
         """
         lengths = {'num_sentence_words': len(word_indices)}
         if len(word_indices) > 0 and not isinstance(word_indices[0], int):
             if isinstance(word_indices[0], list):
-                lengths['max_word_length'] = max([len(word) for word in word_indices])
+                lengths['num_word_characters'] = max([len(word) for word in word_indices])
             # There might someday be other cases we're missing here, but we'll punt for now.
         return lengths
 
@@ -285,14 +285,14 @@ class IndexedInstance(Instance):
         direction, you can.
         """
         default_value = lambda: 0
-        if 'max_word_length' in lengths:
+        if 'num_word_characters' in lengths:
             default_value = lambda: []
 
         padded_word_sequence = IndexedInstance.pad_sequence_to_length(
                 word_sequence, lengths['num_sentence_words'], default_value, truncate_from_right)
-        if 'max_word_length' in lengths:
+        if 'num_word_characters' in lengths:
             padded_word_sequence = [IndexedInstance.pad_sequence_to_length(
-                    word, lengths['max_word_length'], truncate_from_right=False)
+                    word, lengths['num_word_characters'], truncate_from_right=False)
                                     for word in padded_word_sequence]
         return padded_word_sequence
 

--- a/deep_qa/data/instances/instance.py
+++ b/deep_qa/data/instances/instance.py
@@ -238,13 +238,13 @@ class IndexedInstance(Instance):
         dictionary containing 'max_sentence_length', which is the number of
         words in word_indices. If the word representations also contain
         characters, the dictionary additionally contains a
-        'word_character_length' key, with a value corresponding to the longest
+        'max_word_length' key, with a value corresponding to the longest
         word in the sequence.
         """
         lengths = {'max_sentence_length': len(word_indices)}
         if len(word_indices) > 0 and not isinstance(word_indices[0], int):
             if isinstance(word_indices[0], list):
-                lengths['word_character_length'] = max([len(word) for word in word_indices])
+                lengths['max_word_length'] = max([len(word) for word in word_indices])
             # There might someday be other cases we're missing here, but we'll punt for now.
         return lengths
 
@@ -285,14 +285,14 @@ class IndexedInstance(Instance):
         direction, you can.
         """
         default_value = lambda: 0
-        if 'word_character_length' in lengths:
+        if 'max_word_length' in lengths:
             default_value = lambda: []
 
         padded_word_sequence = IndexedInstance.pad_sequence_to_length(
                 word_sequence, lengths['max_sentence_length'], default_value, truncate_from_right)
-        if 'word_character_length' in lengths:
+        if 'max_word_length' in lengths:
             padded_word_sequence = [IndexedInstance.pad_sequence_to_length(
-                    word, lengths['word_character_length'], truncate_from_right=False)
+                    word, lengths['max_word_length'], truncate_from_right=False)
                                     for word in padded_word_sequence]
         return padded_word_sequence
 

--- a/deep_qa/data/instances/mc_question_answer_instance.py
+++ b/deep_qa/data/instances/mc_question_answer_instance.py
@@ -108,7 +108,7 @@ class IndexedMcQuestionAnswerInstance(IndexedQuestionPassageInstance):
         and the word length (in characters) among all the questions, passages,
         and answer options.
         """
-        option_lengths = [self._get_word_sequence_lengths(option) for option in self.option_indices]
+        option_lengths = [self._get_max_sentence_lengths(option) for option in self.option_indices]
 
         lengths = super(IndexedMcQuestionAnswerInstance, self).get_lengths()
 
@@ -116,7 +116,7 @@ class IndexedMcQuestionAnswerInstance(IndexedQuestionPassageInstance):
         lengths['num_options'] = len(self.option_indices)
 
         # the number of words in the longest option
-        lengths['num_option_words'] = max([lengths['word_sequence_length'] for
+        lengths['num_option_words'] = max([lengths['max_sentence_length'] for
                                            lengths in option_lengths])
         # the length of the longest word across the passage, question, and options
         if 'word_character_length' in option_lengths[0]:
@@ -148,7 +148,7 @@ class IndexedMcQuestionAnswerInstance(IndexedQuestionPassageInstance):
         # pad the number of words in the options, number of characters in each word in option
         padded_options = []
         for indices in self.option_indices:
-            max_lengths['word_sequence_length'] = max_lengths['num_option_words']
+            max_lengths['max_sentence_length'] = max_lengths['num_option_words']
             padded_options.append(self.pad_word_sequence(indices, max_lengths))
         self.option_indices = padded_options
 

--- a/deep_qa/data/instances/mc_question_answer_instance.py
+++ b/deep_qa/data/instances/mc_question_answer_instance.py
@@ -108,7 +108,7 @@ class IndexedMcQuestionAnswerInstance(IndexedQuestionPassageInstance):
         and the word length (in characters) among all the questions, passages,
         and answer options.
         """
-        option_lengths = [self._get_max_sentence_lengths(option) for option in self.option_indices]
+        option_lengths = [self._get_num_sentence_wordss(option) for option in self.option_indices]
 
         lengths = super(IndexedMcQuestionAnswerInstance, self).get_lengths()
 
@@ -116,7 +116,7 @@ class IndexedMcQuestionAnswerInstance(IndexedQuestionPassageInstance):
         lengths['num_options'] = len(self.option_indices)
 
         # the number of words in the longest option
-        lengths['num_option_words'] = max([lengths['max_sentence_length'] for
+        lengths['num_option_words'] = max([lengths['num_sentence_words'] for
                                            lengths in option_lengths])
         # the length of the longest word across the passage, question, and options
         if 'max_word_length' in option_lengths[0]:
@@ -148,7 +148,7 @@ class IndexedMcQuestionAnswerInstance(IndexedQuestionPassageInstance):
         # pad the number of words in the options, number of characters in each word in option
         padded_options = []
         for indices in self.option_indices:
-            max_lengths['max_sentence_length'] = max_lengths['num_option_words']
+            max_lengths['num_sentence_words'] = max_lengths['num_option_words']
             padded_options.append(self.pad_word_sequence(indices, max_lengths))
         self.option_indices = padded_options
 

--- a/deep_qa/data/instances/mc_question_answer_instance.py
+++ b/deep_qa/data/instances/mc_question_answer_instance.py
@@ -125,7 +125,7 @@ class IndexedMcQuestionAnswerInstance(IndexedQuestionPassageInstance):
                                           lengths in option_lengths])
 
             lengths['num_word_characters'] = max(lengths['num_word_characters'],
-                                             max_option_word_length)
+                                                 max_option_word_length)
 
         return lengths
 

--- a/deep_qa/data/instances/mc_question_answer_instance.py
+++ b/deep_qa/data/instances/mc_question_answer_instance.py
@@ -108,7 +108,7 @@ class IndexedMcQuestionAnswerInstance(IndexedQuestionPassageInstance):
         and the word length (in characters) among all the questions, passages,
         and answer options.
         """
-        option_lengths = [self._get_word_sequence_lengthss(option) for option in self.option_indices]
+        option_lengths = [self._get_word_sequence_lengths(option) for option in self.option_indices]
 
         lengths = super(IndexedMcQuestionAnswerInstance, self).get_lengths()
 

--- a/deep_qa/data/instances/mc_question_answer_instance.py
+++ b/deep_qa/data/instances/mc_question_answer_instance.py
@@ -119,12 +119,12 @@ class IndexedMcQuestionAnswerInstance(IndexedQuestionPassageInstance):
         lengths['num_option_words'] = max([lengths['max_sentence_length'] for
                                            lengths in option_lengths])
         # the length of the longest word across the passage, question, and options
-        if 'word_character_length' in option_lengths[0]:
+        if 'max_word_length' in option_lengths[0]:
             # length of longest word (in characters) in options
-            max_option_word_length = max([lengths['word_character_length'] for
+            max_option_word_length = max([lengths['max_word_length'] for
                                           lengths in option_lengths])
 
-            lengths['word_character_length'] = max(lengths['word_character_length'],
+            lengths['max_word_length'] = max(lengths['max_word_length'],
                                                    max_option_word_length)
 
         return lengths

--- a/deep_qa/data/instances/mc_question_answer_instance.py
+++ b/deep_qa/data/instances/mc_question_answer_instance.py
@@ -108,7 +108,7 @@ class IndexedMcQuestionAnswerInstance(IndexedQuestionPassageInstance):
         and the word length (in characters) among all the questions, passages,
         and answer options.
         """
-        option_lengths = [self._get_num_sentence_wordss(option) for option in self.option_indices]
+        option_lengths = [self._get_word_sequence_lengthss(option) for option in self.option_indices]
 
         lengths = super(IndexedMcQuestionAnswerInstance, self).get_lengths()
 

--- a/deep_qa/data/instances/mc_question_answer_instance.py
+++ b/deep_qa/data/instances/mc_question_answer_instance.py
@@ -119,12 +119,12 @@ class IndexedMcQuestionAnswerInstance(IndexedQuestionPassageInstance):
         lengths['num_option_words'] = max([lengths['num_sentence_words'] for
                                            lengths in option_lengths])
         # the length of the longest word across the passage, question, and options
-        if 'max_word_length' in option_lengths[0]:
+        if 'num_word_characters' in option_lengths[0]:
             # length of longest word (in characters) in options
-            max_option_word_length = max([lengths['max_word_length'] for
+            max_option_word_length = max([lengths['num_word_characters'] for
                                           lengths in option_lengths])
 
-            lengths['max_word_length'] = max(lengths['max_word_length'],
+            lengths['num_word_characters'] = max(lengths['num_word_characters'],
                                              max_option_word_length)
 
         return lengths

--- a/deep_qa/data/instances/mc_question_answer_instance.py
+++ b/deep_qa/data/instances/mc_question_answer_instance.py
@@ -125,7 +125,7 @@ class IndexedMcQuestionAnswerInstance(IndexedQuestionPassageInstance):
                                           lengths in option_lengths])
 
             lengths['max_word_length'] = max(lengths['max_word_length'],
-                                                   max_option_word_length)
+                                             max_option_word_length)
 
         return lengths
 

--- a/deep_qa/data/instances/question_answer_instance.py
+++ b/deep_qa/data/instances/question_answer_instance.py
@@ -102,10 +102,10 @@ class IndexedQuestionAnswerInstance(IndexedInstance):
         num_options = len(self.option_indices)
         lengths = {}
         lengths.update(question_lengths)
-        if 'max_word_length' in question_lengths:
-            max_answer_character_length = max([lengths['max_word_length'] for lengths in answer_lengths])
-            max_character_length = max([question_lengths['max_word_length'], max_answer_character_length])
-            lengths['max_word_length'] = max_character_length
+        if 'num_word_characters' in question_lengths:
+            max_answer_character_length = max([lengths['num_word_characters'] for lengths in answer_lengths])
+            max_character_length = max([question_lengths['num_word_characters'], max_answer_character_length])
+            lengths['num_word_characters'] = max_character_length
         lengths['answer_length'] = max_answer_length
         lengths['num_options'] = num_options
         return lengths

--- a/deep_qa/data/instances/question_answer_instance.py
+++ b/deep_qa/data/instances/question_answer_instance.py
@@ -96,8 +96,8 @@ class IndexedQuestionAnswerInstance(IndexedInstance):
         number of answer options.  There could also be a fourth: the character length of the words
         in the question and the answers.
         """
-        question_lengths = self._get_num_sentence_wordss(self.question_indices)
-        answer_lengths = [self._get_num_sentence_wordss(option) for option in self.option_indices]
+        question_lengths = self._get_word_sequence_lengthss(self.question_indices)
+        answer_lengths = [self._get_word_sequence_lengthss(option) for option in self.option_indices]
         max_answer_length = max([lengths['num_sentence_words'] for lengths in answer_lengths])
         num_options = len(self.option_indices)
         lengths = {}

--- a/deep_qa/data/instances/question_answer_instance.py
+++ b/deep_qa/data/instances/question_answer_instance.py
@@ -102,10 +102,10 @@ class IndexedQuestionAnswerInstance(IndexedInstance):
         num_options = len(self.option_indices)
         lengths = {}
         lengths.update(question_lengths)
-        if 'word_character_length' in question_lengths:
-            max_answer_character_length = max([lengths['word_character_length'] for lengths in answer_lengths])
-            max_character_length = max([question_lengths['word_character_length'], max_answer_character_length])
-            lengths['word_character_length'] = max_character_length
+        if 'max_word_length' in question_lengths:
+            max_answer_character_length = max([lengths['max_word_length'] for lengths in answer_lengths])
+            max_character_length = max([question_lengths['max_word_length'], max_answer_character_length])
+            lengths['max_word_length'] = max_character_length
         lengths['answer_length'] = max_answer_length
         lengths['num_options'] = num_options
         return lengths

--- a/deep_qa/data/instances/question_answer_instance.py
+++ b/deep_qa/data/instances/question_answer_instance.py
@@ -96,9 +96,9 @@ class IndexedQuestionAnswerInstance(IndexedInstance):
         number of answer options.  There could also be a fourth: the character length of the words
         in the question and the answers.
         """
-        question_lengths = self._get_word_sequence_lengths(self.question_indices)
-        answer_lengths = [self._get_word_sequence_lengths(option) for option in self.option_indices]
-        max_answer_length = max([lengths['word_sequence_length'] for lengths in answer_lengths])
+        question_lengths = self._get_max_sentence_lengths(self.question_indices)
+        answer_lengths = [self._get_max_sentence_lengths(option) for option in self.option_indices]
+        max_answer_length = max([lengths['max_sentence_length'] for lengths in answer_lengths])
         num_options = len(self.option_indices)
         lengths = {}
         lengths.update(question_lengths)
@@ -127,7 +127,7 @@ class IndexedQuestionAnswerInstance(IndexedInstance):
         for indices in self.option_indices:
             answer_lengths = {}
             answer_lengths.update(max_lengths)
-            answer_lengths['word_sequence_length'] = max_lengths['answer_length']
+            answer_lengths['max_sentence_length'] = max_lengths['answer_length']
             padded_options.append(self.pad_word_sequence(indices, answer_lengths))
         self.option_indices = padded_options
 

--- a/deep_qa/data/instances/question_answer_instance.py
+++ b/deep_qa/data/instances/question_answer_instance.py
@@ -96,9 +96,9 @@ class IndexedQuestionAnswerInstance(IndexedInstance):
         number of answer options.  There could also be a fourth: the character length of the words
         in the question and the answers.
         """
-        question_lengths = self._get_max_sentence_lengths(self.question_indices)
-        answer_lengths = [self._get_max_sentence_lengths(option) for option in self.option_indices]
-        max_answer_length = max([lengths['max_sentence_length'] for lengths in answer_lengths])
+        question_lengths = self._get_num_sentence_wordss(self.question_indices)
+        answer_lengths = [self._get_num_sentence_wordss(option) for option in self.option_indices]
+        max_answer_length = max([lengths['num_sentence_words'] for lengths in answer_lengths])
         num_options = len(self.option_indices)
         lengths = {}
         lengths.update(question_lengths)
@@ -127,7 +127,7 @@ class IndexedQuestionAnswerInstance(IndexedInstance):
         for indices in self.option_indices:
             answer_lengths = {}
             answer_lengths.update(max_lengths)
-            answer_lengths['max_sentence_length'] = max_lengths['answer_length']
+            answer_lengths['num_sentence_words'] = max_lengths['answer_length']
             padded_options.append(self.pad_word_sequence(indices, answer_lengths))
         self.option_indices = padded_options
 

--- a/deep_qa/data/instances/question_answer_instance.py
+++ b/deep_qa/data/instances/question_answer_instance.py
@@ -96,8 +96,8 @@ class IndexedQuestionAnswerInstance(IndexedInstance):
         number of answer options.  There could also be a fourth: the character length of the words
         in the question and the answers.
         """
-        question_lengths = self._get_word_sequence_lengthss(self.question_indices)
-        answer_lengths = [self._get_word_sequence_lengthss(option) for option in self.option_indices]
+        question_lengths = self._get_word_sequence_lengths(self.question_indices)
+        answer_lengths = [self._get_word_sequence_lengths(option) for option in self.option_indices]
         max_answer_length = max([lengths['num_sentence_words'] for lengths in answer_lengths])
         num_options = len(self.option_indices)
         lengths = {}

--- a/deep_qa/data/instances/question_passage_instance.py
+++ b/deep_qa/data/instances/question_passage_instance.py
@@ -73,15 +73,15 @@ class IndexedQuestionPassageInstance(IndexedInstance):
         add more arguments should also override this method to enable padding on said
         arguments.
         """
-        question_lengths = self._get_word_sequence_lengths(self.question_indices)
-        passage_lengths = self._get_word_sequence_lengths(self.passage_indices)
+        question_lengths = self._get_max_sentence_lengths(self.question_indices)
+        passage_lengths = self._get_max_sentence_lengths(self.passage_indices)
         lengths = {}
 
         # the number of words to pad the question to
-        lengths['num_question_words'] = question_lengths['word_sequence_length']
+        lengths['num_question_words'] = question_lengths['max_sentence_length']
 
         # the number of words to pad the passage to
-        lengths['num_passage_words'] = passage_lengths['word_sequence_length']
+        lengths['num_passage_words'] = passage_lengths['max_sentence_length']
 
         if 'word_character_length' in question_lengths and 'word_character_length' in passage_lengths:
             # the length of the longest word across the passage and question
@@ -96,9 +96,9 @@ class IndexedQuestionPassageInstance(IndexedInstance):
         as well as the individual words in the questions and passages themselves.
         """
         max_lengths_tmp = max_lengths.copy()
-        max_lengths_tmp['word_sequence_length'] = max_lengths_tmp['num_question_words']
+        max_lengths_tmp['max_sentence_length'] = max_lengths_tmp['num_question_words']
         self.question_indices = self.pad_word_sequence(self.question_indices, max_lengths_tmp)
-        max_lengths_tmp['word_sequence_length'] = max_lengths_tmp['num_passage_words']
+        max_lengths_tmp['max_sentence_length'] = max_lengths_tmp['num_passage_words']
         self.passage_indices = self.pad_word_sequence(self.passage_indices, max_lengths_tmp,
                                                       truncate_from_right=False)
 

--- a/deep_qa/data/instances/question_passage_instance.py
+++ b/deep_qa/data/instances/question_passage_instance.py
@@ -86,7 +86,7 @@ class IndexedQuestionPassageInstance(IndexedInstance):
         if 'max_word_length' in question_lengths and 'max_word_length' in passage_lengths:
             # the length of the longest word across the passage and question
             lengths['max_word_length'] = max(question_lengths['max_word_length'],
-                                                   passage_lengths['max_word_length'])
+                                             passage_lengths['max_word_length'])
         return lengths
 
     @overrides

--- a/deep_qa/data/instances/question_passage_instance.py
+++ b/deep_qa/data/instances/question_passage_instance.py
@@ -83,10 +83,10 @@ class IndexedQuestionPassageInstance(IndexedInstance):
         # the number of words to pad the passage to
         lengths['num_passage_words'] = passage_lengths['max_sentence_length']
 
-        if 'word_character_length' in question_lengths and 'word_character_length' in passage_lengths:
+        if 'max_word_length' in question_lengths and 'max_word_length' in passage_lengths:
             # the length of the longest word across the passage and question
-            lengths['word_character_length'] = max(question_lengths['word_character_length'],
-                                                   passage_lengths['word_character_length'])
+            lengths['max_word_length'] = max(question_lengths['max_word_length'],
+                                                   passage_lengths['max_word_length'])
         return lengths
 
     @overrides

--- a/deep_qa/data/instances/question_passage_instance.py
+++ b/deep_qa/data/instances/question_passage_instance.py
@@ -73,15 +73,15 @@ class IndexedQuestionPassageInstance(IndexedInstance):
         add more arguments should also override this method to enable padding on said
         arguments.
         """
-        question_lengths = self._get_max_sentence_lengths(self.question_indices)
-        passage_lengths = self._get_max_sentence_lengths(self.passage_indices)
+        question_lengths = self._get_num_sentence_wordss(self.question_indices)
+        passage_lengths = self._get_num_sentence_wordss(self.passage_indices)
         lengths = {}
 
         # the number of words to pad the question to
-        lengths['num_question_words'] = question_lengths['max_sentence_length']
+        lengths['num_question_words'] = question_lengths['num_sentence_words']
 
         # the number of words to pad the passage to
-        lengths['num_passage_words'] = passage_lengths['max_sentence_length']
+        lengths['num_passage_words'] = passage_lengths['num_sentence_words']
 
         if 'max_word_length' in question_lengths and 'max_word_length' in passage_lengths:
             # the length of the longest word across the passage and question
@@ -96,9 +96,9 @@ class IndexedQuestionPassageInstance(IndexedInstance):
         as well as the individual words in the questions and passages themselves.
         """
         max_lengths_tmp = max_lengths.copy()
-        max_lengths_tmp['max_sentence_length'] = max_lengths_tmp['num_question_words']
+        max_lengths_tmp['num_sentence_words'] = max_lengths_tmp['num_question_words']
         self.question_indices = self.pad_word_sequence(self.question_indices, max_lengths_tmp)
-        max_lengths_tmp['max_sentence_length'] = max_lengths_tmp['num_passage_words']
+        max_lengths_tmp['num_sentence_words'] = max_lengths_tmp['num_passage_words']
         self.passage_indices = self.pad_word_sequence(self.passage_indices, max_lengths_tmp,
                                                       truncate_from_right=False)
 

--- a/deep_qa/data/instances/question_passage_instance.py
+++ b/deep_qa/data/instances/question_passage_instance.py
@@ -73,8 +73,8 @@ class IndexedQuestionPassageInstance(IndexedInstance):
         add more arguments should also override this method to enable padding on said
         arguments.
         """
-        question_lengths = self._get_num_sentence_wordss(self.question_indices)
-        passage_lengths = self._get_num_sentence_wordss(self.passage_indices)
+        question_lengths = self._get_word_sequence_lengthss(self.question_indices)
+        passage_lengths = self._get_word_sequence_lengthss(self.passage_indices)
         lengths = {}
 
         # the number of words to pad the question to

--- a/deep_qa/data/instances/question_passage_instance.py
+++ b/deep_qa/data/instances/question_passage_instance.py
@@ -86,7 +86,7 @@ class IndexedQuestionPassageInstance(IndexedInstance):
         if 'num_word_characters' in question_lengths and 'num_word_characters' in passage_lengths:
             # the length of the longest word across the passage and question
             lengths['num_word_characters'] = max(question_lengths['num_word_characters'],
-                                             passage_lengths['num_word_characters'])
+                                                 passage_lengths['num_word_characters'])
         return lengths
 
     @overrides

--- a/deep_qa/data/instances/question_passage_instance.py
+++ b/deep_qa/data/instances/question_passage_instance.py
@@ -83,10 +83,10 @@ class IndexedQuestionPassageInstance(IndexedInstance):
         # the number of words to pad the passage to
         lengths['num_passage_words'] = passage_lengths['num_sentence_words']
 
-        if 'max_word_length' in question_lengths and 'max_word_length' in passage_lengths:
+        if 'num_word_characters' in question_lengths and 'num_word_characters' in passage_lengths:
             # the length of the longest word across the passage and question
-            lengths['max_word_length'] = max(question_lengths['max_word_length'],
-                                             passage_lengths['max_word_length'])
+            lengths['num_word_characters'] = max(question_lengths['num_word_characters'],
+                                             passage_lengths['num_word_characters'])
         return lengths
 
     @overrides

--- a/deep_qa/data/instances/question_passage_instance.py
+++ b/deep_qa/data/instances/question_passage_instance.py
@@ -73,8 +73,8 @@ class IndexedQuestionPassageInstance(IndexedInstance):
         add more arguments should also override this method to enable padding on said
         arguments.
         """
-        question_lengths = self._get_word_sequence_lengthss(self.question_indices)
-        passage_lengths = self._get_word_sequence_lengthss(self.passage_indices)
+        question_lengths = self._get_word_sequence_lengths(self.question_indices)
+        passage_lengths = self._get_word_sequence_lengths(self.passage_indices)
         lengths = {}
 
         # the number of words to pad the question to

--- a/deep_qa/data/instances/sentence_pair_instance.py
+++ b/deep_qa/data/instances/sentence_pair_instance.py
@@ -62,8 +62,8 @@ class IndexedSentencePairInstance(IndexedInstance):
 
     @overrides
     def get_lengths(self) -> Dict[str, int]:
-        first_sentence_lengths = self._get_max_sentence_lengths(self.first_sentence_indices)
-        second_sentence_lengths = self._get_max_sentence_lengths(self.second_sentence_indices)
+        first_sentence_lengths = self._get_num_sentence_wordss(self.first_sentence_indices)
+        second_sentence_lengths = self._get_num_sentence_wordss(self.second_sentence_indices)
         lengths = {}
         for key in first_sentence_lengths:
             lengths[key] = max(first_sentence_lengths[key], second_sentence_lengths[key])

--- a/deep_qa/data/instances/sentence_pair_instance.py
+++ b/deep_qa/data/instances/sentence_pair_instance.py
@@ -62,8 +62,8 @@ class IndexedSentencePairInstance(IndexedInstance):
 
     @overrides
     def get_lengths(self) -> Dict[str, int]:
-        first_sentence_lengths = self._get_num_sentence_wordss(self.first_sentence_indices)
-        second_sentence_lengths = self._get_num_sentence_wordss(self.second_sentence_indices)
+        first_sentence_lengths = self._get_word_sequence_lengthss(self.first_sentence_indices)
+        second_sentence_lengths = self._get_word_sequence_lengthss(self.second_sentence_indices)
         lengths = {}
         for key in first_sentence_lengths:
             lengths[key] = max(first_sentence_lengths[key], second_sentence_lengths[key])

--- a/deep_qa/data/instances/sentence_pair_instance.py
+++ b/deep_qa/data/instances/sentence_pair_instance.py
@@ -62,8 +62,8 @@ class IndexedSentencePairInstance(IndexedInstance):
 
     @overrides
     def get_lengths(self) -> Dict[str, int]:
-        first_sentence_lengths = self._get_word_sequence_lengths(self.first_sentence_indices)
-        second_sentence_lengths = self._get_word_sequence_lengths(self.second_sentence_indices)
+        first_sentence_lengths = self._get_max_sentence_lengths(self.first_sentence_indices)
+        second_sentence_lengths = self._get_max_sentence_lengths(self.second_sentence_indices)
         lengths = {}
         for key in first_sentence_lengths:
             lengths[key] = max(first_sentence_lengths[key], second_sentence_lengths[key])

--- a/deep_qa/data/instances/sentence_pair_instance.py
+++ b/deep_qa/data/instances/sentence_pair_instance.py
@@ -62,8 +62,8 @@ class IndexedSentencePairInstance(IndexedInstance):
 
     @overrides
     def get_lengths(self) -> Dict[str, int]:
-        first_sentence_lengths = self._get_word_sequence_lengthss(self.first_sentence_indices)
-        second_sentence_lengths = self._get_word_sequence_lengthss(self.second_sentence_indices)
+        first_sentence_lengths = self._get_word_sequence_lengths(self.first_sentence_indices)
+        second_sentence_lengths = self._get_word_sequence_lengths(self.second_sentence_indices)
         lengths = {}
         for key in first_sentence_lengths:
             lengths[key] = max(first_sentence_lengths[key], second_sentence_lengths[key])

--- a/deep_qa/data/instances/true_false_instance.py
+++ b/deep_qa/data/instances/true_false_instance.py
@@ -95,7 +95,7 @@ class IndexedTrueFalseInstance(IndexedInstance):
         """
         This simple IndexedInstance only has one padding dimension: word_indices.
         """
-        return self._get_max_sentence_lengths(self.word_indices)
+        return self._get_num_sentence_wordss(self.word_indices)
 
     @overrides
     def pad(self, max_lengths: Dict[str, int]):

--- a/deep_qa/data/instances/true_false_instance.py
+++ b/deep_qa/data/instances/true_false_instance.py
@@ -95,7 +95,7 @@ class IndexedTrueFalseInstance(IndexedInstance):
         """
         This simple IndexedInstance only has one padding dimension: word_indices.
         """
-        return self._get_num_sentence_wordss(self.word_indices)
+        return self._get_word_sequence_lengthss(self.word_indices)
 
     @overrides
     def pad(self, max_lengths: Dict[str, int]):

--- a/deep_qa/data/instances/true_false_instance.py
+++ b/deep_qa/data/instances/true_false_instance.py
@@ -95,7 +95,7 @@ class IndexedTrueFalseInstance(IndexedInstance):
         """
         This simple IndexedInstance only has one padding dimension: word_indices.
         """
-        return self._get_word_sequence_lengths(self.word_indices)
+        return self._get_max_sentence_lengths(self.word_indices)
 
     @overrides
     def pad(self, max_lengths: Dict[str, int]):

--- a/deep_qa/data/instances/true_false_instance.py
+++ b/deep_qa/data/instances/true_false_instance.py
@@ -95,7 +95,7 @@ class IndexedTrueFalseInstance(IndexedInstance):
         """
         This simple IndexedInstance only has one padding dimension: word_indices.
         """
-        return self._get_word_sequence_lengthss(self.word_indices)
+        return self._get_word_sequence_lengths(self.word_indices)
 
     @overrides
     def pad(self, max_lengths: Dict[str, int]):

--- a/deep_qa/data/instances/tuple_inference_instance.py
+++ b/deep_qa/data/instances/tuple_inference_instance.py
@@ -266,28 +266,28 @@ class IndexedTupleInferenceInstance(IndexedInstance):
     def get_lengths(self) -> Dict[str, int]:
         # We care only about the longest slot here because all slots will be padded to the same length.
         max_slot_length = 0
-        max_word_length = 0
+        num_word_characters = 0
         max_num_slots = 0
         max_question_tuples = 0
         for answer in self.answers_indexed:
             answer_slots, answer_length, answer_word_length = self.get_lengths_from_indexed_tuples(answer)
             max_num_slots = max(max_num_slots, answer_slots)
             max_slot_length = max(max_slot_length, answer_length)
-            max_word_length = max(max_word_length, answer_word_length)
+            num_word_characters = max(num_word_characters, answer_word_length)
             max_question_tuples = max(max_question_tuples, len(answer))
         background_slots, background_length, background_word_length = \
             self.get_lengths_from_indexed_tuples(self.background_indexed)
         max_num_slots = max(max_num_slots, background_slots)
         max_slot_length = max(max_slot_length, background_length)
-        max_word_length = max(max_word_length, background_word_length)
+        num_word_characters = max(num_word_characters, background_word_length)
 
         lengths = {'num_options': len(self.answers_indexed),
                    'num_question_tuples': max_question_tuples,
                    'num_background_tuples': len(self.background_indexed),
                    'num_sentence_words': max_slot_length,
                    'num_slots': max_num_slots}
-        if max_word_length > 0:
-            lengths['max_word_length'] = max_word_length
+        if num_word_characters > 0:
+            lengths['num_word_characters'] = num_word_characters
         return lengths
 
     @staticmethod
@@ -309,22 +309,22 @@ class IndexedTupleInferenceInstance(IndexedInstance):
         max_slot_words: int
             The max number of words found in any of the slots.
 
-        max_word_length: int
+        num_word_characters: int
             The length of the longest word, with a return value of 0 if the model isn't using character padding.
         '''
         max_num_slots = 0
         max_slot_words = 0
-        max_word_length = 0
+        num_word_characters = 0
         for indexed_tuple in indexed_tuples:
             num_slots = len(indexed_tuple)
             max_num_slots = max(max_num_slots, num_slots)
             for slot in indexed_tuple:
                 num_sentence_wordss = IndexedInstance._get_num_sentence_wordss(slot)
                 max_slot_words = max(max_slot_words, num_sentence_wordss['num_sentence_words'])
-                if 'max_word_length' in num_sentence_wordss:
-                    max_word_length = max(max_word_length, num_sentence_wordss['max_word_length'])
+                if 'num_word_characters' in num_sentence_wordss:
+                    num_word_characters = max(num_word_characters, num_sentence_wordss['num_word_characters'])
 
-        return max_num_slots, max_slot_words, max_word_length
+        return max_num_slots, max_slot_words, num_word_characters
 
     @overrides
     def pad(self, max_lengths: Dict[str, int]):
@@ -388,7 +388,7 @@ class IndexedTupleInferenceInstance(IndexedInstance):
                 - 'num_slots': the number of slots desired
                 - 'num_sentence_words': the number of words in a given slot
             May also include:
-                - 'max_word_length': the length of each word,
+                - 'num_word_characters': the length of each word,
                 relevant when using a ``WordAndCharacterTokenizer``.
 
         Returns

--- a/deep_qa/data/instances/tuple_inference_instance.py
+++ b/deep_qa/data/instances/tuple_inference_instance.py
@@ -319,7 +319,7 @@ class IndexedTupleInferenceInstance(IndexedInstance):
             num_slots = len(indexed_tuple)
             max_num_slots = max(max_num_slots, num_slots)
             for slot in indexed_tuple:
-                num_sentence_wordss = IndexedInstance._get_num_sentence_wordss(slot)
+                num_sentence_wordss = IndexedInstance._get_word_sequence_lengthss(slot)
                 max_slot_words = max(max_slot_words, num_sentence_wordss['num_sentence_words'])
                 if 'num_word_characters' in num_sentence_wordss:
                     num_word_characters = max(num_word_characters, num_sentence_wordss['num_word_characters'])

--- a/deep_qa/data/instances/tuple_inference_instance.py
+++ b/deep_qa/data/instances/tuple_inference_instance.py
@@ -287,7 +287,7 @@ class IndexedTupleInferenceInstance(IndexedInstance):
                    'max_sentence_length': max_slot_length,
                    'num_slots': max_num_slots}
         if max_word_length > 0:
-            lengths['word_character_length'] = max_word_length
+            lengths['max_word_length'] = max_word_length
         return lengths
 
     @staticmethod
@@ -321,8 +321,8 @@ class IndexedTupleInferenceInstance(IndexedInstance):
             for slot in indexed_tuple:
                 max_sentence_lengths = IndexedInstance._get_max_sentence_lengths(slot)
                 max_slot_words = max(max_slot_words, max_sentence_lengths['max_sentence_length'])
-                if 'word_character_length' in max_sentence_lengths:
-                    max_word_length = max(max_word_length, max_sentence_lengths['word_character_length'])
+                if 'max_word_length' in max_sentence_lengths:
+                    max_word_length = max(max_word_length, max_sentence_lengths['max_word_length'])
 
         return max_num_slots, max_slot_words, max_word_length
 
@@ -388,7 +388,7 @@ class IndexedTupleInferenceInstance(IndexedInstance):
                 - 'num_slots': the number of slots desired
                 - 'max_sentence_length': the number of words in a given slot
             May also include:
-                - 'word_character_length': the length of each word,
+                - 'max_word_length': the length of each word,
                 relevant when using a ``WordAndCharacterTokenizer``.
 
         Returns

--- a/deep_qa/data/instances/tuple_inference_instance.py
+++ b/deep_qa/data/instances/tuple_inference_instance.py
@@ -284,7 +284,7 @@ class IndexedTupleInferenceInstance(IndexedInstance):
         lengths = {'num_options': len(self.answers_indexed),
                    'num_question_tuples': max_question_tuples,
                    'num_background_tuples': len(self.background_indexed),
-                   'max_sentence_length': max_slot_length,
+                   'num_sentence_words': max_slot_length,
                    'num_slots': max_num_slots}
         if max_word_length > 0:
             lengths['max_word_length'] = max_word_length
@@ -319,10 +319,10 @@ class IndexedTupleInferenceInstance(IndexedInstance):
             num_slots = len(indexed_tuple)
             max_num_slots = max(max_num_slots, num_slots)
             for slot in indexed_tuple:
-                max_sentence_lengths = IndexedInstance._get_max_sentence_lengths(slot)
-                max_slot_words = max(max_slot_words, max_sentence_lengths['max_sentence_length'])
-                if 'max_word_length' in max_sentence_lengths:
-                    max_word_length = max(max_word_length, max_sentence_lengths['max_word_length'])
+                num_sentence_wordss = IndexedInstance._get_num_sentence_wordss(slot)
+                max_slot_words = max(max_slot_words, num_sentence_wordss['num_sentence_words'])
+                if 'max_word_length' in num_sentence_wordss:
+                    max_word_length = max(max_word_length, num_sentence_wordss['max_word_length'])
 
         return max_num_slots, max_slot_words, max_word_length
 
@@ -386,7 +386,7 @@ class IndexedTupleInferenceInstance(IndexedInstance):
         max_lengths: Dict of {str: int}
             The lengths to pad to.  Must include the keys:
                 - 'num_slots': the number of slots desired
-                - 'max_sentence_length': the number of words in a given slot
+                - 'num_sentence_words': the number of words in a given slot
             May also include:
                 - 'max_word_length': the length of each word,
                 relevant when using a ``WordAndCharacterTokenizer``.
@@ -395,7 +395,7 @@ class IndexedTupleInferenceInstance(IndexedInstance):
         -------
         tuple_in: List[List[int]]
             In the returned (modified) list, the length matches the desired_num_slots and each of the slots
-            has a length equal to the value set by 'max_sentence_length' in max_lengths.
+            has a length equal to the value set by 'num_sentence_words' in max_lengths.
         '''
         desired_num_slots = max_lengths['num_slots']
         tuple_in = self.pad_sequence_to_length(tuple_in, desired_num_slots,

--- a/deep_qa/data/instances/tuple_inference_instance.py
+++ b/deep_qa/data/instances/tuple_inference_instance.py
@@ -284,7 +284,7 @@ class IndexedTupleInferenceInstance(IndexedInstance):
         lengths = {'num_options': len(self.answers_indexed),
                    'num_question_tuples': max_question_tuples,
                    'num_background_tuples': len(self.background_indexed),
-                   'word_sequence_length': max_slot_length,
+                   'max_sentence_length': max_slot_length,
                    'num_slots': max_num_slots}
         if max_word_length > 0:
             lengths['word_character_length'] = max_word_length
@@ -319,10 +319,10 @@ class IndexedTupleInferenceInstance(IndexedInstance):
             num_slots = len(indexed_tuple)
             max_num_slots = max(max_num_slots, num_slots)
             for slot in indexed_tuple:
-                word_sequence_lengths = IndexedInstance._get_word_sequence_lengths(slot)
-                max_slot_words = max(max_slot_words, word_sequence_lengths['word_sequence_length'])
-                if 'word_character_length' in word_sequence_lengths:
-                    max_word_length = max(max_word_length, word_sequence_lengths['word_character_length'])
+                max_sentence_lengths = IndexedInstance._get_max_sentence_lengths(slot)
+                max_slot_words = max(max_slot_words, max_sentence_lengths['max_sentence_length'])
+                if 'word_character_length' in max_sentence_lengths:
+                    max_word_length = max(max_word_length, max_sentence_lengths['word_character_length'])
 
         return max_num_slots, max_slot_words, max_word_length
 
@@ -386,7 +386,7 @@ class IndexedTupleInferenceInstance(IndexedInstance):
         max_lengths: Dict of {str: int}
             The lengths to pad to.  Must include the keys:
                 - 'num_slots': the number of slots desired
-                - 'word_sequence_length': the number of words in a given slot
+                - 'max_sentence_length': the number of words in a given slot
             May also include:
                 - 'word_character_length': the length of each word,
                 relevant when using a ``WordAndCharacterTokenizer``.
@@ -395,7 +395,7 @@ class IndexedTupleInferenceInstance(IndexedInstance):
         -------
         tuple_in: List[List[int]]
             In the returned (modified) list, the length matches the desired_num_slots and each of the slots
-            has a length equal to the value set by 'word_sequence_length' in max_lengths.
+            has a length equal to the value set by 'max_sentence_length' in max_lengths.
         '''
         desired_num_slots = max_lengths['num_slots']
         tuple_in = self.pad_sequence_to_length(tuple_in, desired_num_slots,

--- a/deep_qa/data/instances/tuple_inference_instance.py
+++ b/deep_qa/data/instances/tuple_inference_instance.py
@@ -319,7 +319,7 @@ class IndexedTupleInferenceInstance(IndexedInstance):
             num_slots = len(indexed_tuple)
             max_num_slots = max(max_num_slots, num_slots)
             for slot in indexed_tuple:
-                num_sentence_wordss = IndexedInstance._get_word_sequence_lengthss(slot)
+                num_sentence_wordss = IndexedInstance._get_word_sequence_lengths(slot)
                 max_slot_words = max(max_slot_words, num_sentence_wordss['num_sentence_words'])
                 if 'num_word_characters' in num_sentence_wordss:
                     num_word_characters = max(num_word_characters, num_sentence_wordss['num_word_characters'])

--- a/deep_qa/data/instances/tuple_instance.py
+++ b/deep_qa/data/instances/tuple_instance.py
@@ -92,7 +92,7 @@ class IndexedTupleInstance(IndexedInstance):
     @overrides
     def get_lengths(self) -> Dict[str, int]:
         # We care only about the longest slot here because all slots will be padded to the same length.
-        return {'word_sequence_length': max([len(indices) for indices in self.word_indices]),
+        return {'max_sentence_length': max([len(indices) for indices in self.word_indices]),
                 'num_slots': len(self.word_indices)}
 
     @overrides

--- a/deep_qa/data/instances/tuple_instance.py
+++ b/deep_qa/data/instances/tuple_instance.py
@@ -92,7 +92,7 @@ class IndexedTupleInstance(IndexedInstance):
     @overrides
     def get_lengths(self) -> Dict[str, int]:
         # We care only about the longest slot here because all slots will be padded to the same length.
-        return {'max_sentence_length': max([len(indices) for indices in self.word_indices]),
+        return {'num_sentence_words': max([len(indices) for indices in self.word_indices]),
                 'num_slots': len(self.word_indices)}
 
     @overrides

--- a/deep_qa/data/tokenizers/character_tokenizer.py
+++ b/deep_qa/data/tokenizers/character_tokenizer.py
@@ -45,5 +45,5 @@ class CharacterTokenizer(Tokenizer):
     def get_max_lengths(self, sentence_length: int, word_length: int) -> Dict[str, int]:
         # Note that `sentence_length` here is the number of _characters_ in the sentence, because
         # of how `self.index_text` works.  And even though the name isn't great, we'll use
-        # `max_sentence_length` for the key to this, so that the rest of the code is simpler.
-        return {'max_sentence_length': sentence_length}
+        # `num_sentence_words` for the key to this, so that the rest of the code is simpler.
+        return {'num_sentence_words': sentence_length}

--- a/deep_qa/data/tokenizers/character_tokenizer.py
+++ b/deep_qa/data/tokenizers/character_tokenizer.py
@@ -45,5 +45,5 @@ class CharacterTokenizer(Tokenizer):
     def get_max_lengths(self, sentence_length: int, word_length: int) -> Dict[str, int]:
         # Note that `sentence_length` here is the number of _characters_ in the sentence, because
         # of how `self.index_text` works.  And even though the name isn't great, we'll use
-        # `word_sequence_length` for the key to this, so that the rest of the code is simpler.
-        return {'word_sequence_length': sentence_length}
+        # `max_sentence_length` for the key to this, so that the rest of the code is simpler.
+        return {'max_sentence_length': sentence_length}

--- a/deep_qa/data/tokenizers/word_and_character_tokenizer.py
+++ b/deep_qa/data/tokenizers/word_and_character_tokenizer.py
@@ -128,4 +128,4 @@ class WordAndCharacterTokenizer(Tokenizer):
 
     @overrides
     def get_max_lengths(self, sentence_length: int, word_length: int) -> Dict[str, int]:
-        return {'max_sentence_length': sentence_length, 'max_word_length': word_length}
+        return {'num_sentence_words': sentence_length, 'max_word_length': word_length}

--- a/deep_qa/data/tokenizers/word_and_character_tokenizer.py
+++ b/deep_qa/data/tokenizers/word_and_character_tokenizer.py
@@ -128,4 +128,4 @@ class WordAndCharacterTokenizer(Tokenizer):
 
     @overrides
     def get_max_lengths(self, sentence_length: int, word_length: int) -> Dict[str, int]:
-        return {'word_sequence_length': sentence_length, 'word_character_length': word_length}
+        return {'max_sentence_length': sentence_length, 'word_character_length': word_length}

--- a/deep_qa/data/tokenizers/word_and_character_tokenizer.py
+++ b/deep_qa/data/tokenizers/word_and_character_tokenizer.py
@@ -128,4 +128,4 @@ class WordAndCharacterTokenizer(Tokenizer):
 
     @overrides
     def get_max_lengths(self, sentence_length: int, word_length: int) -> Dict[str, int]:
-        return {'max_sentence_length': sentence_length, 'word_character_length': word_length}
+        return {'max_sentence_length': sentence_length, 'max_word_length': word_length}

--- a/deep_qa/data/tokenizers/word_and_character_tokenizer.py
+++ b/deep_qa/data/tokenizers/word_and_character_tokenizer.py
@@ -128,4 +128,4 @@ class WordAndCharacterTokenizer(Tokenizer):
 
     @overrides
     def get_max_lengths(self, sentence_length: int, word_length: int) -> Dict[str, int]:
-        return {'num_sentence_words': sentence_length, 'max_word_length': word_length}
+        return {'num_sentence_words': sentence_length, 'num_word_characters': word_length}

--- a/deep_qa/data/tokenizers/word_tokenizer.py
+++ b/deep_qa/data/tokenizers/word_tokenizer.py
@@ -57,4 +57,4 @@ class WordTokenizer(Tokenizer):
 
     @overrides
     def get_max_lengths(self, sentence_length: int, word_length: int) -> Dict[str, int]:
-        return {'max_sentence_length': sentence_length}
+        return {'num_sentence_words': sentence_length}

--- a/deep_qa/data/tokenizers/word_tokenizer.py
+++ b/deep_qa/data/tokenizers/word_tokenizer.py
@@ -57,4 +57,4 @@ class WordTokenizer(Tokenizer):
 
     @overrides
     def get_max_lengths(self, sentence_length: int, word_length: int) -> Dict[str, int]:
-        return {'word_sequence_length': sentence_length}
+        return {'max_sentence_length': sentence_length}

--- a/deep_qa/models/memory_networks/memory_network.py
+++ b/deep_qa/models/memory_networks/memory_network.py
@@ -151,7 +151,7 @@ class MemoryNetwork(TextTrainer):
 
     @overrides
     def _set_max_lengths_from_model(self):
-        self.max_sentence_length = self.model.get_input_shape_at(0)[0][1]
+        self.num_sentence_words = self.model.get_input_shape_at(0)[0][1]
         self.max_knowledge_length = self.model.get_input_shape_at(0)[1][1]
 
     def _get_question_shape(self):

--- a/deep_qa/models/multiple_choice_qa/question_answer_similarity.py
+++ b/deep_qa/models/multiple_choice_qa/question_answer_similarity.py
@@ -69,7 +69,7 @@ class QuestionAnswerSimilarity(TextTrainer):
         # This needs to use a new encoder because we can't compile the same LSTM with two different
         # padding lengths...  If you really want to use the same LSTM for both questions and
         # answers, pad the answers to the same dimension as the questions, replacing
-        # self.max_answer_length with self.max_sentence_length everywhere.
+        # self.max_answer_length with self.num_sentence_words everywhere.
         answer_encoder = EncoderWrapper(question_encoder, name="answer_encoder")
         encoded_answers = answer_encoder(answer_embedding)
 
@@ -103,5 +103,5 @@ class QuestionAnswerSimilarity(TextTrainer):
 
     @overrides
     def _set_max_lengths_from_model(self):
-        self.max_sentence_length = self.model.get_input_shape_at(0)[1]
+        self.num_sentence_words = self.model.get_input_shape_at(0)[1]
         # TODO(matt): implement this correctly

--- a/deep_qa/models/multiple_choice_qa/tuple_entailment.py
+++ b/deep_qa/models/multiple_choice_qa/tuple_entailment.py
@@ -54,7 +54,7 @@ class MultipleChoiceTupleEntailmentModel(TextTrainer):
     @overrides
     def _get_max_lengths(self) -> Dict[str, int]:
         return {
-                'word_sequence_length': self.max_sentence_length,
+                'max_sentence_length': self.max_sentence_length,
                 'answer_length': self.max_answer_length,
                 'background_sentences': self.max_knowledge_length,
                 'num_options': self.num_options,
@@ -63,7 +63,7 @@ class MultipleChoiceTupleEntailmentModel(TextTrainer):
 
     @overrides
     def _set_max_lengths(self, max_lengths: Dict[str, int]):
-        self.max_sentence_length = max_lengths['word_sequence_length']
+        self.max_sentence_length = max_lengths['max_sentence_length']
         self.max_answer_length = max_lengths['answer_length']
         self.max_knowledge_length = max_lengths['background_sentences']
         self.num_options = max_lengths['num_options']

--- a/deep_qa/models/multiple_choice_qa/tuple_entailment.py
+++ b/deep_qa/models/multiple_choice_qa/tuple_entailment.py
@@ -54,7 +54,7 @@ class MultipleChoiceTupleEntailmentModel(TextTrainer):
     @overrides
     def _get_max_lengths(self) -> Dict[str, int]:
         return {
-                'max_sentence_length': self.max_sentence_length,
+                'num_sentence_words': self.num_sentence_words,
                 'answer_length': self.max_answer_length,
                 'background_sentences': self.max_knowledge_length,
                 'num_options': self.num_options,
@@ -63,7 +63,7 @@ class MultipleChoiceTupleEntailmentModel(TextTrainer):
 
     @overrides
     def _set_max_lengths(self, max_lengths: Dict[str, int]):
-        self.max_sentence_length = max_lengths['max_sentence_length']
+        self.num_sentence_words = max_lengths['num_sentence_words']
         self.max_answer_length = max_lengths['answer_length']
         self.max_knowledge_length = max_lengths['background_sentences']
         self.num_options = max_lengths['num_options']
@@ -76,9 +76,9 @@ class MultipleChoiceTupleEntailmentModel(TextTrainer):
 
     @overrides
     def _build_model(self):
-        question_input = Input((self.max_sentence_length,), dtype='int32', name='question_input')
+        question_input = Input((self.num_sentence_words,), dtype='int32', name='question_input')
         answer_input = Input((self.num_options, self.max_answer_length), dtype='int32', name='answer_input')
-        knowledge_input = Input((self.max_knowledge_length, self.num_slots, self.max_sentence_length),
+        knowledge_input = Input((self.max_knowledge_length, self.num_slots, self.num_sentence_words),
                                 dtype='int32', name='knowledge_input')
         question_embedding = self._embed_input(question_input)
         answer_embedding = self._embed_input(answer_input)

--- a/deep_qa/models/multiple_choice_qa/tuple_inference.py
+++ b/deep_qa/models/multiple_choice_qa/tuple_inference.py
@@ -55,7 +55,7 @@ class TupleInferenceModel(TextTrainer):
         self.num_question_tuples = params.pop('num_question_tuples', 10)
         self.num_background_tuples = params.pop('num_background_tuples', 10)
         self.num_tuple_slots = params.pop('num_tuple_slots', 4)
-        self.num_slot_words = params.pop('word_sequence_length', 5)
+        self.num_slot_words = params.pop('max_sentence_length', 5)
         self.num_options = params.pop('num_answer_options', 4)
         tuple_matcher_params = params.pop('tuple_matcher', {})
         tuple_matcher_choice = get_choice_with_default(tuple_matcher_params,
@@ -98,7 +98,7 @@ class TupleInferenceModel(TextTrainer):
         max_lengths['num_question_tuples'] = self.num_question_tuples
         max_lengths['num_background_tuples'] = self.num_background_tuples
         max_lengths['num_slots'] = self.num_tuple_slots
-        max_lengths['word_sequence_length'] = self.num_slot_words
+        max_lengths['max_sentence_length'] = self.num_slot_words
         max_lengths['num_options'] = self.num_options
         return max_lengths
 
@@ -108,7 +108,7 @@ class TupleInferenceModel(TextTrainer):
         self.num_question_tuples = max_lengths['num_question_tuples']
         self.num_background_tuples = max_lengths['num_background_tuples']
         self.num_tuple_slots = max_lengths['num_slots']
-        self.num_slot_words = max_lengths['word_sequence_length']
+        self.num_slot_words = max_lengths['max_sentence_length']
         self.num_options = max_lengths['num_options']
 
     @overrides

--- a/deep_qa/models/multiple_choice_qa/tuple_inference.py
+++ b/deep_qa/models/multiple_choice_qa/tuple_inference.py
@@ -55,7 +55,7 @@ class TupleInferenceModel(TextTrainer):
         self.num_question_tuples = params.pop('num_question_tuples', 10)
         self.num_background_tuples = params.pop('num_background_tuples', 10)
         self.num_tuple_slots = params.pop('num_tuple_slots', 4)
-        self.num_slot_words = params.pop('max_sentence_length', 5)
+        self.num_slot_words = params.pop('num_sentence_words', 5)
         self.num_options = params.pop('num_answer_options', 4)
         tuple_matcher_params = params.pop('tuple_matcher', {})
         tuple_matcher_choice = get_choice_with_default(tuple_matcher_params,
@@ -98,7 +98,7 @@ class TupleInferenceModel(TextTrainer):
         max_lengths['num_question_tuples'] = self.num_question_tuples
         max_lengths['num_background_tuples'] = self.num_background_tuples
         max_lengths['num_slots'] = self.num_tuple_slots
-        max_lengths['max_sentence_length'] = self.num_slot_words
+        max_lengths['num_sentence_words'] = self.num_slot_words
         max_lengths['num_options'] = self.num_options
         return max_lengths
 
@@ -108,7 +108,7 @@ class TupleInferenceModel(TextTrainer):
         self.num_question_tuples = max_lengths['num_question_tuples']
         self.num_background_tuples = max_lengths['num_background_tuples']
         self.num_tuple_slots = max_lengths['num_slots']
-        self.num_slot_words = max_lengths['max_sentence_length']
+        self.num_slot_words = max_lengths['num_sentence_words']
         self.num_options = max_lengths['num_options']
 
     @overrides

--- a/deep_qa/models/reading_comprehension/attention_sum_reader.py
+++ b/deep_qa/models/reading_comprehension/attention_sum_reader.py
@@ -130,9 +130,9 @@ class AttentionSumReader(TextTrainer):
         Set the padding lengths of the model.
         """
         # TODO(nelson): superclass complains that there is no
-        # word_sequence_length key, so we set it to None here.
+        # max_sentence_length key, so we set it to None here.
         # We should probably patch up / organize the API.
-        max_lengths["word_sequence_length"] = None
+        max_lengths["max_sentence_length"] = None
         super(AttentionSumReader, self)._set_max_lengths(max_lengths)
         self.max_question_length = max_lengths['num_question_words']
         self.max_passage_length = max_lengths['num_passage_words']

--- a/deep_qa/models/reading_comprehension/attention_sum_reader.py
+++ b/deep_qa/models/reading_comprehension/attention_sum_reader.py
@@ -130,9 +130,9 @@ class AttentionSumReader(TextTrainer):
         Set the padding lengths of the model.
         """
         # TODO(nelson): superclass complains that there is no
-        # max_sentence_length key, so we set it to None here.
+        # num_sentence_words key, so we set it to None here.
         # We should probably patch up / organize the API.
-        max_lengths["max_sentence_length"] = None
+        max_lengths["num_sentence_words"] = None
         super(AttentionSumReader, self)._set_max_lengths(max_lengths)
         self.max_question_length = max_lengths['num_question_words']
         self.max_passage_length = max_lengths['num_passage_words']
@@ -141,7 +141,7 @@ class AttentionSumReader(TextTrainer):
 
     @overrides
     def _set_max_lengths_from_model(self):
-        self.max_sentence_length = self.model.get_input_shape_at(0)[1]
+        self.num_sentence_words = self.model.get_input_shape_at(0)[1]
         # TODO(matt): implement this correctly
 
     @classmethod

--- a/deep_qa/models/reading_comprehension/bidirectional_attention.py
+++ b/deep_qa/models/reading_comprehension/bidirectional_attention.py
@@ -219,7 +219,7 @@ class BidirectionalAttentionFlow(TextTrainer):
         self.num_question_words = self.model.get_input_shape_at(0)[0][1]
         self.num_passage_words = self.model.get_input_shape_at(0)[1][1]
         # We need to pass this slice of the passage input shape to the superclass
-        # mainly to set self.max_word_length. The decision of whether to pass
+        # mainly to set self.num_word_characters. The decision of whether to pass
         # the passage input or the question input is arbitrary, as the
         # two word lengths are guaranteed to be the same and BiDAF ignores
         # self.num_sentence_words.

--- a/deep_qa/models/reading_comprehension/bidirectional_attention.py
+++ b/deep_qa/models/reading_comprehension/bidirectional_attention.py
@@ -207,9 +207,9 @@ class BidirectionalAttentionFlow(TextTrainer):
 
     @overrides
     def _set_max_lengths(self, max_lengths: Dict[str, int]):
-        # Adding this because we're bypassing max_sentence_length in our model, but TextTrainer
+        # Adding this because we're bypassing num_sentence_words in our model, but TextTrainer
         # expects it.
-        max_lengths['max_sentence_length'] = None
+        max_lengths['num_sentence_words'] = None
         super(BidirectionalAttentionFlow, self)._set_max_lengths(max_lengths)
         self.num_passage_words = max_lengths['num_passage_words']
         self.num_question_words = max_lengths['num_question_words']
@@ -222,7 +222,7 @@ class BidirectionalAttentionFlow(TextTrainer):
         # mainly to set self.max_word_length. The decision of whether to pass
         # the passage input or the question input is arbitrary, as the
         # two word lengths are guaranteed to be the same and BiDAF ignores
-        # self.max_sentence_length.
+        # self.num_sentence_words.
         self.set_text_lengths_from_model_input(self.model.get_input_shape_at(0)[1][2:])
 
     @classmethod

--- a/deep_qa/models/reading_comprehension/bidirectional_attention.py
+++ b/deep_qa/models/reading_comprehension/bidirectional_attention.py
@@ -207,9 +207,9 @@ class BidirectionalAttentionFlow(TextTrainer):
 
     @overrides
     def _set_max_lengths(self, max_lengths: Dict[str, int]):
-        # Adding this because we're bypassing word_sequence_length in our model, but TextTrainer
+        # Adding this because we're bypassing max_sentence_length in our model, but TextTrainer
         # expects it.
-        max_lengths['word_sequence_length'] = None
+        max_lengths['max_sentence_length'] = None
         super(BidirectionalAttentionFlow, self)._set_max_lengths(max_lengths)
         self.num_passage_words = max_lengths['num_passage_words']
         self.num_question_words = max_lengths['num_question_words']

--- a/deep_qa/models/reading_comprehension/gated_attention_reader.py
+++ b/deep_qa/models/reading_comprehension/gated_attention_reader.py
@@ -251,9 +251,9 @@ class GatedAttentionReader(TextTrainer):
         Set the padding lengths of the model.
         """
         # TODO(nelson): superclass complains that there is no
-        # word_sequence_length key, so we set it to None here.
+        # max_sentence_length key, so we set it to None here.
         # We should probably patch up / organize the API.
-        max_lengths["word_sequence_length"] = None
+        max_lengths["max_sentence_length"] = None
         super(GatedAttentionReader, self)._set_max_lengths(max_lengths)
         self.max_question_length = max_lengths['num_question_words']
         self.max_passage_length = max_lengths['num_passage_words']

--- a/deep_qa/models/reading_comprehension/gated_attention_reader.py
+++ b/deep_qa/models/reading_comprehension/gated_attention_reader.py
@@ -251,9 +251,9 @@ class GatedAttentionReader(TextTrainer):
         Set the padding lengths of the model.
         """
         # TODO(nelson): superclass complains that there is no
-        # max_sentence_length key, so we set it to None here.
+        # num_sentence_words key, so we set it to None here.
         # We should probably patch up / organize the API.
-        max_lengths["max_sentence_length"] = None
+        max_lengths["num_sentence_words"] = None
         super(GatedAttentionReader, self)._set_max_lengths(max_lengths)
         self.max_question_length = max_lengths['num_question_words']
         self.max_passage_length = max_lengths['num_passage_words']
@@ -262,7 +262,7 @@ class GatedAttentionReader(TextTrainer):
 
     @overrides
     def _set_max_lengths_from_model(self):
-        self.max_sentence_length = self.model.get_input_shape_at(0)[1]
+        self.num_sentence_words = self.model.get_input_shape_at(0)[1]
         # TODO(matt): implement this correctly
 
     @overrides

--- a/deep_qa/models/text_classification/tree_lstm_model.py
+++ b/deep_qa/models/text_classification/tree_lstm_model.py
@@ -36,7 +36,7 @@ class TreeLSTMModel(TextTrainer):
         # Step 1: Initialze the transition inputs.
         # Length of transitions (ops) is an upper limit on the stack and buffer sizes. So we'll use
         # that to initialize the stack and buffer in the LSTM.
-        buffer_ops_limit = self.max_sentence_length
+        buffer_ops_limit = self.num_sentence_words
         stack_limit = buffer_ops_limit
 
         # The transitions input has an extra trailing dimension to make the concatenation with the
@@ -80,7 +80,7 @@ class TreeLSTMModel(TextTrainer):
 
     @overrides
     def _set_max_lengths_from_model(self):
-        self.max_sentence_length = self.model.get_input_shape_at(0)[0][1]
+        self.num_sentence_words = self.model.get_input_shape_at(0)[0][1]
         # TODO(matt): set the max transition length.
 
     @classmethod

--- a/deep_qa/training/text_trainer.py
+++ b/deep_qa/training/text_trainer.py
@@ -49,7 +49,7 @@ class TextTrainer(Trainer):
         params.
     embedding_dropout: float, optional (default=0.5)
         Dropout parameter to apply to the word embedding layer
-    max_sentence_length: int, optional (default=None)
+    num_sentence_words: int, optional (default=None)
         Upper limit on length of word sequences in the training data. Ignored during testing (we
         use the value set at training time, either from this parameter or from a loaded model).  If
         this is not set, we'll calculate a max length from the data.
@@ -90,7 +90,7 @@ class TextTrainer(Trainer):
         self.project_embeddings = params.pop('project_embeddings', False)
         self.embedding_size = params.pop('embedding_size', 50)
         self.embedding_dropout = params.pop('embedding_dropout', 0.5)
-        self.max_sentence_length = params.pop('max_sentence_length', None)
+        self.num_sentence_words = params.pop('num_sentence_words', None)
         self.max_word_length = params.pop('max_word_length', None)
 
         tokenizer_params = params.pop('tokenizer', {})
@@ -225,7 +225,7 @@ class TextTrainer(Trainer):
             self._build_sentence_encoder_model()
         instance = TrueFalseInstance(sentence, True)
         indexed_instance = instance.to_indexed_instance(self.data_indexer)
-        indexed_instance.pad({'max_sentence_length': self.max_sentence_length})
+        indexed_instance.pad({'num_sentence_words': self.num_sentence_words})
         instance_input, _ = indexed_instance.as_training_data()
         encoded_instance = self._sentence_encoder_model.predict(numpy.asarray([instance_input]))
         return encoded_instance[0]
@@ -240,7 +240,7 @@ class TextTrainer(Trainer):
         have additional padding dimensions, call super()._get_max_lengths() and then update the
         dictionary.
         """
-        return self.tokenizer.get_max_lengths(self.max_sentence_length, self.max_word_length)
+        return self.tokenizer.get_max_lengths(self.num_sentence_words, self.max_word_length)
 
     def _set_max_lengths(self, max_lengths: Dict[str, int]):
         """
@@ -249,7 +249,7 @@ class TextTrainer(Trainer):
         variables given a dictionary of lengths, perhaps computed from training data or loaded from
         a saved model.
         """
-        self.max_sentence_length = max_lengths['max_sentence_length']
+        self.num_sentence_words = max_lengths['num_sentence_words']
         self.max_word_length = max_lengths.get('max_word_length', None)
 
     @overrides
@@ -296,7 +296,7 @@ class TextTrainer(Trainer):
             raise ValueError("Length of input tuple must be "
                              "2 or 1, got input tuple of "
                              "length {}".format(len(input_slice)))
-        self.max_sentence_length = input_slice[0]
+        self.num_sentence_words = input_slice[0]
         if len(input_slice) == 2:
             self.max_word_length = input_slice[1]
 
@@ -318,13 +318,13 @@ class TextTrainer(Trainer):
     def _get_sentence_shape(self, sentence_length: int=None) -> Tuple[int]:
         """
         Returns a tuple specifying the shape of a tensor representing a sentence.  This is not
-        necessarily just (self.max_sentence_length,), because different text_encodings lead to
+        necessarily just (self.num_sentence_words,), because different text_encodings lead to
         different tensor shapes.
         """
         if sentence_length is None:
             # This can't be the default value for the function argument, because
-            # self.max_sentence_length will not have been set at class creation time.
-            sentence_length = self.max_sentence_length
+            # self.num_sentence_words will not have been set at class creation time.
+            sentence_length = self.num_sentence_words
         return self.tokenizer.get_sentence_shape(sentence_length, self.max_word_length)
 
     def _embed_input(self, input_layer: Layer, embedding_name: str="embedding"):
@@ -556,10 +556,10 @@ class TextTrainer(Trainer):
         embedding sequences, and the part of the model that gets us from word embedding sequences
         to sentence vectors.
 
-        This must be called after self.max_sentence_length has been set, which happens when
+        This must be called after self.num_sentence_words has been set, which happens when
         self._get_training_data() is called.
         """
-        sentence_input = Input(shape=(self.max_sentence_length,), dtype='int32', name="sentence_input")
+        sentence_input = Input(shape=(self.num_sentence_words,), dtype='int32', name="sentence_input")
         embedded_input = self._embed_input(sentence_input)
         encoder_layer = self._get_encoder()
         encoded_input = encoder_layer(embedded_input)

--- a/deep_qa/training/text_trainer.py
+++ b/deep_qa/training/text_trainer.py
@@ -225,7 +225,7 @@ class TextTrainer(Trainer):
             self._build_sentence_encoder_model()
         instance = TrueFalseInstance(sentence, True)
         indexed_instance = instance.to_indexed_instance(self.data_indexer)
-        indexed_instance.pad({'word_sequence_length': self.max_sentence_length})
+        indexed_instance.pad({'max_sentence_length': self.max_sentence_length})
         instance_input, _ = indexed_instance.as_training_data()
         encoded_instance = self._sentence_encoder_model.predict(numpy.asarray([instance_input]))
         return encoded_instance[0]
@@ -249,7 +249,7 @@ class TextTrainer(Trainer):
         variables given a dictionary of lengths, perhaps computed from training data or loaded from
         a saved model.
         """
-        self.max_sentence_length = max_lengths['word_sequence_length']
+        self.max_sentence_length = max_lengths['max_sentence_length']
         self.max_word_length = max_lengths.get('word_character_length', None)
 
     @overrides

--- a/deep_qa/training/text_trainer.py
+++ b/deep_qa/training/text_trainer.py
@@ -250,7 +250,7 @@ class TextTrainer(Trainer):
         a saved model.
         """
         self.max_sentence_length = max_lengths['max_sentence_length']
-        self.max_word_length = max_lengths.get('word_character_length', None)
+        self.max_word_length = max_lengths.get('max_word_length', None)
 
     @overrides
     def _set_params_from_model(self):

--- a/deep_qa/training/text_trainer.py
+++ b/deep_qa/training/text_trainer.py
@@ -53,7 +53,7 @@ class TextTrainer(Trainer):
         Upper limit on length of word sequences in the training data. Ignored during testing (we
         use the value set at training time, either from this parameter or from a loaded model).  If
         this is not set, we'll calculate a max length from the data.
-    max_word_length: int, optional (default=None)
+    num_word_characters: int, optional (default=None)
         Upper limit on length of words in the training data. Only applicable for "words and
         characters" text encoding.
     tokenizer: Dict[str, Any], optional (default={})
@@ -91,7 +91,7 @@ class TextTrainer(Trainer):
         self.embedding_size = params.pop('embedding_size', 50)
         self.embedding_dropout = params.pop('embedding_dropout', 0.5)
         self.num_sentence_words = params.pop('num_sentence_words', None)
-        self.max_word_length = params.pop('max_word_length', None)
+        self.num_word_characters = params.pop('num_word_characters', None)
 
         tokenizer_params = params.pop('tokenizer', {})
         tokenizer_choice = get_choice_with_default(tokenizer_params, 'type', list(tokenizers.keys()))
@@ -240,7 +240,7 @@ class TextTrainer(Trainer):
         have additional padding dimensions, call super()._get_max_lengths() and then update the
         dictionary.
         """
-        return self.tokenizer.get_max_lengths(self.num_sentence_words, self.max_word_length)
+        return self.tokenizer.get_max_lengths(self.num_sentence_words, self.num_word_characters)
 
     def _set_max_lengths(self, max_lengths: Dict[str, int]):
         """
@@ -250,7 +250,7 @@ class TextTrainer(Trainer):
         a saved model.
         """
         self.num_sentence_words = max_lengths['num_sentence_words']
-        self.max_word_length = max_lengths.get('max_word_length', None)
+        self.num_word_characters = max_lengths.get('num_word_characters', None)
 
     @overrides
     def _set_params_from_model(self):
@@ -298,7 +298,7 @@ class TextTrainer(Trainer):
                              "length {}".format(len(input_slice)))
         self.num_sentence_words = input_slice[0]
         if len(input_slice) == 2:
-            self.max_word_length = input_slice[1]
+            self.num_word_characters = input_slice[1]
 
     def _instance_type(self) -> Instance:
         """
@@ -325,7 +325,7 @@ class TextTrainer(Trainer):
             # This can't be the default value for the function argument, because
             # self.num_sentence_words will not have been set at class creation time.
             sentence_length = self.num_sentence_words
-        return self.tokenizer.get_sentence_shape(sentence_length, self.max_word_length)
+        return self.tokenizer.get_sentence_shape(sentence_length, self.num_word_characters)
 
     def _embed_input(self, input_layer: Layer, embedding_name: str="embedding"):
         """

--- a/example_experiments/dynamic_memory_network.json
+++ b/example_experiments/dynamic_memory_network.json
@@ -22,7 +22,7 @@
         "type": "memory_only"
     },
     "num_memory_layers": 1,
-    "max_sentence_length": 125,
+    "num_sentence_words": 125,
     "max_training_instances": 10,
     "train_files": [
         "data/science/omnibus_questions/processed_questions.tsv",

--- a/example_experiments/gareader_sciq.json
+++ b/example_experiments/gareader_sciq.json
@@ -5,7 +5,7 @@
     "project_embeddings": False,
     "model_class": "GatedAttentionReader",
     "model_serialization_prefix": "models/multiple_choice_qa/gareader_sciq",
-    "max_word_length": 10,
+    "num_word_characters": 10,
     "num_gated_attention_layers": 3,
     "preferred_backend": "theano",
     "tokenizer": {

--- a/example_experiments/gareader_who_did_what.json
+++ b/example_experiments/gareader_who_did_what.json
@@ -5,7 +5,7 @@
     "embedding_size": 200,
     "model_class": "GatedAttentionReader",
     "cloze_token": "xxxxx",
-    "max_word_length": 10,
+    "num_word_characters": 10,
     "model_serialization_prefix": "models/multiple_choice_qa/gareader_wdw",
     "num_gated_attention_layers": 3,
     "preferred_backend": "theano",

--- a/example_experiments/pretraining_encoder.json
+++ b/example_experiments/pretraining_encoder.json
@@ -16,7 +16,7 @@
         "type": "memory_only"
     },
     "num_memory_layers": 1,
-    "max_sentence_length": 125,
+    "num_sentence_words": 125,
     "max_training_instances": 10,
     "train_files": [
         "/home/pdasigi/data/ai2_omnibus/processed/omnibus_4_and_8_train.tsv",

--- a/example_experiments/question_answer_lstm.json
+++ b/example_experiments/question_answer_lstm.json
@@ -7,7 +7,7 @@
         }
     },
     "patience": 5,
-    "max_sentence_length": 70,
+    "num_sentence_words": 70,
     "max_answer_length": 70,
     "train_files": ["data/science/omnibus_questions/processed_questions_and_answers.tsv"]
 }

--- a/example_experiments/simple_adaptive_experiment.json
+++ b/example_experiments/simple_adaptive_experiment.json
@@ -19,7 +19,7 @@
         "type": "memory_only"
     },
     "num_memory_layers": 1,
-    "max_sentence_length": 125,
+    "num_sentence_words": 125,
     "patience": 5,
     "show_summary_with_masking_info": true,
     "train_files": [

--- a/example_experiments/simple_experiment.json
+++ b/example_experiments/simple_experiment.json
@@ -19,7 +19,7 @@
         "type": "memory_only"
     },
     "num_memory_layers": 1,
-    "max_sentence_length": 125,
+    "num_sentence_words": 125,
     "patience": 5,
     "show_summary_with_masking_info": true,
     //"max_training_instances": 10,

--- a/example_experiments/svo_mc_tuple_entailment.json
+++ b/example_experiments/svo_mc_tuple_entailment.json
@@ -34,7 +34,7 @@
     "num_question_tuples": 30,
     "num_background_tuples": 50,
     "num_tuple_slots": 4,
-    "word_sequence_length": 5,
+    "max_sentence_length": 5,
     "num_answer_options": 4,
     "train_files": ["/Users/rebeccas/data/brittleness/omni4_train_brittleness.tuples.labeled"]
 

--- a/example_experiments/svo_mc_tuple_entailment.json
+++ b/example_experiments/svo_mc_tuple_entailment.json
@@ -34,7 +34,7 @@
     "num_question_tuples": 30,
     "num_background_tuples": 50,
     "num_tuple_slots": 4,
-    "max_sentence_length": 5,
+    "num_sentence_words": 5,
     "num_answer_options": 4,
     "train_files": ["/Users/rebeccas/data/brittleness/omni4_train_brittleness.tuples.labeled"]
 

--- a/example_experiments/tuple_entailment.json
+++ b/example_experiments/tuple_entailment.json
@@ -7,7 +7,7 @@
         }
     },
     "patience": 5,
-    "max_sentence_length": 70,
+    "num_sentence_words": 70,
     "max_answer_length": 20,
     "max_knowledge_length": 30,
     "num_tuple_slots": 3,

--- a/tests/data/instances/background_instance_test.py
+++ b/tests/data/instances/background_instance_test.py
@@ -18,27 +18,27 @@ class TestIndexedBackgroundInstance(DeepQaTestCase):
 
     def test_get_lengths_returns_max_of_background_and_word_indices(self):
         instance = IndexedBackgroundInstance(self.base_instance, self.background_instances)
-        assert instance.get_lengths()['word_sequence_length'] == 3
+        assert instance.get_lengths()['max_sentence_length'] == 3
 
     def test_get_lengths_returns_correct_background_length(self):
         instance = IndexedBackgroundInstance(self.base_instance, self.background_instances)
-        assert instance.get_lengths() == {'word_sequence_length': 3, 'background_sentences': 2}
+        assert instance.get_lengths() == {'max_sentence_length': 3, 'background_sentences': 2}
 
     def test_pad_adds_zeros_on_left_to_background(self):
         instance = IndexedBackgroundInstance(self.base_instance, self.background_instances[1:])
-        instance.pad({'word_sequence_length': 3, 'background_sentences': 1})
+        instance.pad({'max_sentence_length': 3, 'background_sentences': 1})
         assert instance.indexed_instance.word_indices == [0, 1, 2]
         assert instance.background_instances[0].word_indices == [0, 4, 5]
 
     def test_pad_truncates_from_right_on_background(self):
         instance = IndexedBackgroundInstance(self.base_instance, self.background_instances[1:])
-        instance.pad({'word_sequence_length': 1, 'background_sentences': 1})
+        instance.pad({'max_sentence_length': 1, 'background_sentences': 1})
         assert instance.indexed_instance.word_indices == [2]
         assert instance.background_instances[0].word_indices == [5]
 
     def test_pad_adds_padded_background_at_end(self):
         instance = IndexedBackgroundInstance(self.base_instance, self.background_instances[1:])
-        instance.pad({'word_sequence_length': 2, 'background_sentences': 2})
+        instance.pad({'max_sentence_length': 2, 'background_sentences': 2})
         assert instance.indexed_instance.word_indices == [1, 2]
         assert len(instance.background_instances) == 2
         assert instance.background_instances[0].word_indices == [4, 5]
@@ -46,7 +46,7 @@ class TestIndexedBackgroundInstance(DeepQaTestCase):
 
     def test_pad_truncates_background_from_left(self):
         instance = IndexedBackgroundInstance(self.base_instance, self.background_instances)
-        instance.pad({'word_sequence_length': 1, 'background_sentences': 1})
+        instance.pad({'max_sentence_length': 1, 'background_sentences': 1})
         assert instance.indexed_instance.word_indices == [2]
         assert len(instance.background_instances) == 1
         assert instance.background_instances[0].word_indices == [4]
@@ -54,7 +54,7 @@ class TestIndexedBackgroundInstance(DeepQaTestCase):
     def test_pad_works_with_complex_contained_instance(self):
         instance = IndexedBackgroundInstance(self.qa_instance, self.background_instances[1:])
         instance.pad({
-                'word_sequence_length': 3,
+                'max_sentence_length': 3,
                 'answer_length': 1,
                 'num_options': 2,
                 'background_sentences': 2,
@@ -69,7 +69,7 @@ class TestIndexedBackgroundInstance(DeepQaTestCase):
 
     def test_as_training_data_produces_correct_numpy_arrays(self):
         instance = IndexedBackgroundInstance(self.base_instance, self.background_instances)
-        instance.pad({'word_sequence_length': 3, 'background_sentences': 2})
+        instance.pad({'max_sentence_length': 3, 'background_sentences': 2})
         (word_array, background_array), label = instance.as_training_data()
         assert numpy.all(label == numpy.asarray([0, 1]))
         assert numpy.all(word_array == numpy.asarray([0, 1, 2]))
@@ -85,7 +85,7 @@ class TestIndexedBackgroundInstance(DeepQaTestCase):
         # We need the background array to always be _second_, not last.
         instance = IndexedBackgroundInstance(self.qa_instance, self.background_instances)
         instance.pad({
-                'word_sequence_length': 2,
+                'max_sentence_length': 2,
                 'answer_length': 2,
                 'num_options': 3,
                 'background_sentences': 2,

--- a/tests/data/instances/background_instance_test.py
+++ b/tests/data/instances/background_instance_test.py
@@ -18,27 +18,27 @@ class TestIndexedBackgroundInstance(DeepQaTestCase):
 
     def test_get_lengths_returns_max_of_background_and_word_indices(self):
         instance = IndexedBackgroundInstance(self.base_instance, self.background_instances)
-        assert instance.get_lengths()['max_sentence_length'] == 3
+        assert instance.get_lengths()['num_sentence_words'] == 3
 
     def test_get_lengths_returns_correct_background_length(self):
         instance = IndexedBackgroundInstance(self.base_instance, self.background_instances)
-        assert instance.get_lengths() == {'max_sentence_length': 3, 'background_sentences': 2}
+        assert instance.get_lengths() == {'num_sentence_words': 3, 'background_sentences': 2}
 
     def test_pad_adds_zeros_on_left_to_background(self):
         instance = IndexedBackgroundInstance(self.base_instance, self.background_instances[1:])
-        instance.pad({'max_sentence_length': 3, 'background_sentences': 1})
+        instance.pad({'num_sentence_words': 3, 'background_sentences': 1})
         assert instance.indexed_instance.word_indices == [0, 1, 2]
         assert instance.background_instances[0].word_indices == [0, 4, 5]
 
     def test_pad_truncates_from_right_on_background(self):
         instance = IndexedBackgroundInstance(self.base_instance, self.background_instances[1:])
-        instance.pad({'max_sentence_length': 1, 'background_sentences': 1})
+        instance.pad({'num_sentence_words': 1, 'background_sentences': 1})
         assert instance.indexed_instance.word_indices == [2]
         assert instance.background_instances[0].word_indices == [5]
 
     def test_pad_adds_padded_background_at_end(self):
         instance = IndexedBackgroundInstance(self.base_instance, self.background_instances[1:])
-        instance.pad({'max_sentence_length': 2, 'background_sentences': 2})
+        instance.pad({'num_sentence_words': 2, 'background_sentences': 2})
         assert instance.indexed_instance.word_indices == [1, 2]
         assert len(instance.background_instances) == 2
         assert instance.background_instances[0].word_indices == [4, 5]
@@ -46,7 +46,7 @@ class TestIndexedBackgroundInstance(DeepQaTestCase):
 
     def test_pad_truncates_background_from_left(self):
         instance = IndexedBackgroundInstance(self.base_instance, self.background_instances)
-        instance.pad({'max_sentence_length': 1, 'background_sentences': 1})
+        instance.pad({'num_sentence_words': 1, 'background_sentences': 1})
         assert instance.indexed_instance.word_indices == [2]
         assert len(instance.background_instances) == 1
         assert instance.background_instances[0].word_indices == [4]
@@ -54,7 +54,7 @@ class TestIndexedBackgroundInstance(DeepQaTestCase):
     def test_pad_works_with_complex_contained_instance(self):
         instance = IndexedBackgroundInstance(self.qa_instance, self.background_instances[1:])
         instance.pad({
-                'max_sentence_length': 3,
+                'num_sentence_words': 3,
                 'answer_length': 1,
                 'num_options': 2,
                 'background_sentences': 2,
@@ -69,7 +69,7 @@ class TestIndexedBackgroundInstance(DeepQaTestCase):
 
     def test_as_training_data_produces_correct_numpy_arrays(self):
         instance = IndexedBackgroundInstance(self.base_instance, self.background_instances)
-        instance.pad({'max_sentence_length': 3, 'background_sentences': 2})
+        instance.pad({'num_sentence_words': 3, 'background_sentences': 2})
         (word_array, background_array), label = instance.as_training_data()
         assert numpy.all(label == numpy.asarray([0, 1]))
         assert numpy.all(word_array == numpy.asarray([0, 1, 2]))
@@ -85,7 +85,7 @@ class TestIndexedBackgroundInstance(DeepQaTestCase):
         # We need the background array to always be _second_, not last.
         instance = IndexedBackgroundInstance(self.qa_instance, self.background_instances)
         instance.pad({
-                'max_sentence_length': 2,
+                'num_sentence_words': 2,
                 'answer_length': 2,
                 'num_options': 3,
                 'background_sentences': 2,

--- a/tests/data/instances/multiple_true_false_instance_test.py
+++ b/tests/data/instances/multiple_true_false_instance_test.py
@@ -22,17 +22,17 @@ class TestIndexedMultipleTrueFalseInstance(DeepQaTestCase):
                 2)
 
     def test_get_lengths_returns_max_of_options(self):
-        assert self.instance.get_lengths() == {'max_sentence_length': 3, 'num_options': 4}
+        assert self.instance.get_lengths() == {'num_sentence_words': 3, 'num_options': 4}
 
     def test_pad_calls_pad_on_all_options(self):
-        self.instance.pad({'max_sentence_length': 3, 'num_options': 4})
+        self.instance.pad({'num_sentence_words': 3, 'num_options': 4})
         assert self.instance.options[0].word_indices == [0, 0, 1]
         assert self.instance.options[1].word_indices == [2, 3, 4]
         assert self.instance.options[2].word_indices == [0, 5, 6]
         assert self.instance.options[3].word_indices == [0, 7, 8]
 
     def test_pad_adds_empty_options_when_necessary(self):
-        self.instance.pad({'max_sentence_length': 2, 'num_options': 5})
+        self.instance.pad({'num_sentence_words': 2, 'num_options': 5})
         assert self.instance.options[0].word_indices == [0, 1]
         assert self.instance.options[1].word_indices == [3, 4]
         assert self.instance.options[2].word_indices == [5, 6]
@@ -41,12 +41,12 @@ class TestIndexedMultipleTrueFalseInstance(DeepQaTestCase):
         assert len(self.instance.options) == 5
 
     def test_pad_removes_options_when_necessary(self):
-        self.instance.pad({'max_sentence_length': 1, 'num_options': 1})
+        self.instance.pad({'num_sentence_words': 1, 'num_options': 1})
         assert self.instance.options[0].word_indices == [1]
         assert len(self.instance.options) == 1
 
     def test_as_training_data_produces_correct_numpy_arrays_with_simple_instances(self):
-        self.instance.pad({'max_sentence_length': 3, 'num_options': 4})
+        self.instance.pad({'num_sentence_words': 3, 'num_options': 4})
         inputs, label = self.instance.as_training_data()
         assert numpy.all(label == numpy.asarray([0, 0, 1, 0]))
         assert numpy.all(inputs == numpy.asarray([[0, 0, 1], [2, 3, 4], [0, 5, 6], [0, 7, 8]]))

--- a/tests/data/instances/multiple_true_false_instance_test.py
+++ b/tests/data/instances/multiple_true_false_instance_test.py
@@ -22,17 +22,17 @@ class TestIndexedMultipleTrueFalseInstance(DeepQaTestCase):
                 2)
 
     def test_get_lengths_returns_max_of_options(self):
-        assert self.instance.get_lengths() == {'word_sequence_length': 3, 'num_options': 4}
+        assert self.instance.get_lengths() == {'max_sentence_length': 3, 'num_options': 4}
 
     def test_pad_calls_pad_on_all_options(self):
-        self.instance.pad({'word_sequence_length': 3, 'num_options': 4})
+        self.instance.pad({'max_sentence_length': 3, 'num_options': 4})
         assert self.instance.options[0].word_indices == [0, 0, 1]
         assert self.instance.options[1].word_indices == [2, 3, 4]
         assert self.instance.options[2].word_indices == [0, 5, 6]
         assert self.instance.options[3].word_indices == [0, 7, 8]
 
     def test_pad_adds_empty_options_when_necessary(self):
-        self.instance.pad({'word_sequence_length': 2, 'num_options': 5})
+        self.instance.pad({'max_sentence_length': 2, 'num_options': 5})
         assert self.instance.options[0].word_indices == [0, 1]
         assert self.instance.options[1].word_indices == [3, 4]
         assert self.instance.options[2].word_indices == [5, 6]
@@ -41,12 +41,12 @@ class TestIndexedMultipleTrueFalseInstance(DeepQaTestCase):
         assert len(self.instance.options) == 5
 
     def test_pad_removes_options_when_necessary(self):
-        self.instance.pad({'word_sequence_length': 1, 'num_options': 1})
+        self.instance.pad({'max_sentence_length': 1, 'num_options': 1})
         assert self.instance.options[0].word_indices == [1]
         assert len(self.instance.options) == 1
 
     def test_as_training_data_produces_correct_numpy_arrays_with_simple_instances(self):
-        self.instance.pad({'word_sequence_length': 3, 'num_options': 4})
+        self.instance.pad({'max_sentence_length': 3, 'num_options': 4})
         inputs, label = self.instance.as_training_data()
         assert numpy.all(label == numpy.asarray([0, 0, 1, 0]))
         assert numpy.all(inputs == numpy.asarray([[0, 0, 1], [2, 3, 4], [0, 5, 6], [0, 7, 8]]))

--- a/tests/data/instances/question_answer_instance_test.py
+++ b/tests/data/instances/question_answer_instance_test.py
@@ -70,20 +70,20 @@ class TestIndexedQuestionAnswerInstance(DeepQaTestCase):
 
     def test_get_lengths_returns_three_correct_lengths(self):
         assert self.instance.get_lengths() == {
-                'max_sentence_length': 3,
+                'num_sentence_words': 3,
                 'answer_length': 2,
                 'num_options': 3
                 }
 
     def test_pad_calls_pad_on_all_options(self):
-        self.instance.pad({'max_sentence_length': 2, 'answer_length': 2, 'num_options': 3})
+        self.instance.pad({'num_sentence_words': 2, 'answer_length': 2, 'num_options': 3})
         assert self.instance.question_indices == [2, 3]
         assert self.instance.option_indices[0] == [2, 3]
         assert self.instance.option_indices[1] == [0, 4]
         assert self.instance.option_indices[2] == [5, 6]
 
     def test_pad_adds_empty_options_when_necessary(self):
-        self.instance.pad({'max_sentence_length': 1, 'answer_length': 1, 'num_options': 4})
+        self.instance.pad({'num_sentence_words': 1, 'answer_length': 1, 'num_options': 4})
         assert self.instance.question_indices == [3]
         assert self.instance.option_indices[0] == [3]
         assert self.instance.option_indices[1] == [4]
@@ -92,13 +92,13 @@ class TestIndexedQuestionAnswerInstance(DeepQaTestCase):
         assert len(self.instance.option_indices) == 4
 
     def test_pad_removes_options_when_necessary(self):
-        self.instance.pad({'max_sentence_length': 1, 'answer_length': 1, 'num_options': 1})
+        self.instance.pad({'num_sentence_words': 1, 'answer_length': 1, 'num_options': 1})
         assert self.instance.question_indices == [3]
         assert self.instance.option_indices[0] == [3]
         assert len(self.instance.option_indices) == 1
 
     def test_as_training_data_produces_correct_numpy_arrays(self):
-        self.instance.pad({'max_sentence_length': 3, 'answer_length': 2, 'num_options': 3})
+        self.instance.pad({'num_sentence_words': 3, 'answer_length': 2, 'num_options': 3})
         inputs, label = self.instance.as_training_data()
         assert numpy.all(label == numpy.asarray([0, 1, 0]))
         assert numpy.all(inputs[0] == numpy.asarray([1, 2, 3]))

--- a/tests/data/instances/question_answer_instance_test.py
+++ b/tests/data/instances/question_answer_instance_test.py
@@ -70,20 +70,20 @@ class TestIndexedQuestionAnswerInstance(DeepQaTestCase):
 
     def test_get_lengths_returns_three_correct_lengths(self):
         assert self.instance.get_lengths() == {
-                'word_sequence_length': 3,
+                'max_sentence_length': 3,
                 'answer_length': 2,
                 'num_options': 3
                 }
 
     def test_pad_calls_pad_on_all_options(self):
-        self.instance.pad({'word_sequence_length': 2, 'answer_length': 2, 'num_options': 3})
+        self.instance.pad({'max_sentence_length': 2, 'answer_length': 2, 'num_options': 3})
         assert self.instance.question_indices == [2, 3]
         assert self.instance.option_indices[0] == [2, 3]
         assert self.instance.option_indices[1] == [0, 4]
         assert self.instance.option_indices[2] == [5, 6]
 
     def test_pad_adds_empty_options_when_necessary(self):
-        self.instance.pad({'word_sequence_length': 1, 'answer_length': 1, 'num_options': 4})
+        self.instance.pad({'max_sentence_length': 1, 'answer_length': 1, 'num_options': 4})
         assert self.instance.question_indices == [3]
         assert self.instance.option_indices[0] == [3]
         assert self.instance.option_indices[1] == [4]
@@ -92,13 +92,13 @@ class TestIndexedQuestionAnswerInstance(DeepQaTestCase):
         assert len(self.instance.option_indices) == 4
 
     def test_pad_removes_options_when_necessary(self):
-        self.instance.pad({'word_sequence_length': 1, 'answer_length': 1, 'num_options': 1})
+        self.instance.pad({'max_sentence_length': 1, 'answer_length': 1, 'num_options': 1})
         assert self.instance.question_indices == [3]
         assert self.instance.option_indices[0] == [3]
         assert len(self.instance.option_indices) == 1
 
     def test_as_training_data_produces_correct_numpy_arrays(self):
-        self.instance.pad({'word_sequence_length': 3, 'answer_length': 2, 'num_options': 3})
+        self.instance.pad({'max_sentence_length': 3, 'answer_length': 2, 'num_options': 3})
         inputs, label = self.instance.as_training_data()
         assert numpy.all(label == numpy.asarray([0, 1, 0]))
         assert numpy.all(inputs[0] == numpy.asarray([1, 2, 3]))

--- a/tests/data/instances/sentence_pair_instance_test.py
+++ b/tests/data/instances/sentence_pair_instance_test.py
@@ -8,13 +8,13 @@ from ...common.test_case import DeepQaTestCase
 class TestIndexedSentencePairInstance(DeepQaTestCase):
     def test_get_lengths_returns_max_of_both_sentences(self):
         instance = IndexedSentencePairInstance([1, 2, 3], [1], True)
-        assert instance.get_lengths() == {'word_sequence_length': 3}
+        assert instance.get_lengths() == {'max_sentence_length': 3}
         instance = IndexedSentencePairInstance([1, 2, 3], [1, 2, 3, 4], True)
-        assert instance.get_lengths() == {'word_sequence_length': 4}
+        assert instance.get_lengths() == {'max_sentence_length': 4}
 
     def test_pad_pads_both_sentences(self):
         instance = IndexedSentencePairInstance([1, 2], [3, 4], True)
-        instance.pad({'word_sequence_length': 3})
+        instance.pad({'max_sentence_length': 3})
         assert instance.first_sentence_indices == [0, 1, 2]
         assert instance.second_sentence_indices == [0, 3, 4]
 

--- a/tests/data/instances/sentence_pair_instance_test.py
+++ b/tests/data/instances/sentence_pair_instance_test.py
@@ -8,13 +8,13 @@ from ...common.test_case import DeepQaTestCase
 class TestIndexedSentencePairInstance(DeepQaTestCase):
     def test_get_lengths_returns_max_of_both_sentences(self):
         instance = IndexedSentencePairInstance([1, 2, 3], [1], True)
-        assert instance.get_lengths() == {'max_sentence_length': 3}
+        assert instance.get_lengths() == {'num_sentence_words': 3}
         instance = IndexedSentencePairInstance([1, 2, 3], [1, 2, 3, 4], True)
-        assert instance.get_lengths() == {'max_sentence_length': 4}
+        assert instance.get_lengths() == {'num_sentence_words': 4}
 
     def test_pad_pads_both_sentences(self):
         instance = IndexedSentencePairInstance([1, 2], [3, 4], True)
-        instance.pad({'max_sentence_length': 3})
+        instance.pad({'num_sentence_words': 3})
         assert instance.first_sentence_indices == [0, 1, 2]
         assert instance.second_sentence_indices == [0, 3, 4]
 

--- a/tests/data/instances/sequence_tagging/test_tagging_instance.py
+++ b/tests/data/instances/sequence_tagging/test_tagging_instance.py
@@ -11,14 +11,14 @@ class TestIndexedTaggingInstance(DeepQaTestCase):
         self.instance = IndexedTaggingInstance([1, 2, 3, 4], [4, 5, 6])
 
     def test_get_lengths_returns_correct_lengths(self):
-        assert self.instance.get_lengths() == {'word_sequence_length': 4}
+        assert self.instance.get_lengths() == {'num_sentence_words': 4}
 
     def test_pad_truncates_correctly(self):
-        self.instance.pad({'word_sequence_length': 2})
+        self.instance.pad({'num_sentence_words': 2})
         assert self.instance.text_indices == [1, 2]
 
     def test_pad_adds_padding_correctly(self):
-        self.instance.pad({'word_sequence_length': 6})
+        self.instance.pad({'num_sentence_words': 6})
         assert self.instance.text_indices == [1, 2, 3, 4, 0, 0]
 
     def test_as_training_data_produces_correct_arrays(self):

--- a/tests/data/instances/text_instance_test.py
+++ b/tests/data/instances/text_instance_test.py
@@ -53,10 +53,10 @@ class TestTextInstance:
 class TestIndexedInstance(DeepQaTestCase):
     def test_get_lengths_works_with_words_and_characters(self):
         instance = IndexedTrueFalseInstance([[1, 2], [3, 1, 2]], True)
-        assert instance.get_lengths() == {'max_sentence_length': 2, 'word_character_length': 3}
+        assert instance.get_lengths() == {'max_sentence_length': 2, 'max_word_length': 3}
 
     def test_pad_word_sequence_handles_words_and_characters(self):
         instance = IndexedTrueFalseInstance([[1, 2], [3, 1, 2]], True)
         padded = instance.pad_word_sequence(instance.word_indices,
-                                            {'max_sentence_length': 3, 'word_character_length': 4})
+                                            {'max_sentence_length': 3, 'max_word_length': 4})
         assert padded == [[0, 0, 0, 0], [1, 2, 0, 0], [3, 1, 2, 0]]

--- a/tests/data/instances/text_instance_test.py
+++ b/tests/data/instances/text_instance_test.py
@@ -53,10 +53,10 @@ class TestTextInstance:
 class TestIndexedInstance(DeepQaTestCase):
     def test_get_lengths_works_with_words_and_characters(self):
         instance = IndexedTrueFalseInstance([[1, 2], [3, 1, 2]], True)
-        assert instance.get_lengths() == {'max_sentence_length': 2, 'max_word_length': 3}
+        assert instance.get_lengths() == {'num_sentence_words': 2, 'max_word_length': 3}
 
     def test_pad_word_sequence_handles_words_and_characters(self):
         instance = IndexedTrueFalseInstance([[1, 2], [3, 1, 2]], True)
         padded = instance.pad_word_sequence(instance.word_indices,
-                                            {'max_sentence_length': 3, 'max_word_length': 4})
+                                            {'num_sentence_words': 3, 'max_word_length': 4})
         assert padded == [[0, 0, 0, 0], [1, 2, 0, 0], [3, 1, 2, 0]]

--- a/tests/data/instances/text_instance_test.py
+++ b/tests/data/instances/text_instance_test.py
@@ -53,10 +53,10 @@ class TestTextInstance:
 class TestIndexedInstance(DeepQaTestCase):
     def test_get_lengths_works_with_words_and_characters(self):
         instance = IndexedTrueFalseInstance([[1, 2], [3, 1, 2]], True)
-        assert instance.get_lengths() == {'num_sentence_words': 2, 'max_word_length': 3}
+        assert instance.get_lengths() == {'num_sentence_words': 2, 'num_word_characters': 3}
 
     def test_pad_word_sequence_handles_words_and_characters(self):
         instance = IndexedTrueFalseInstance([[1, 2], [3, 1, 2]], True)
         padded = instance.pad_word_sequence(instance.word_indices,
-                                            {'num_sentence_words': 3, 'max_word_length': 4})
+                                            {'num_sentence_words': 3, 'num_word_characters': 4})
         assert padded == [[0, 0, 0, 0], [1, 2, 0, 0], [3, 1, 2, 0]]

--- a/tests/data/instances/text_instance_test.py
+++ b/tests/data/instances/text_instance_test.py
@@ -53,10 +53,10 @@ class TestTextInstance:
 class TestIndexedInstance(DeepQaTestCase):
     def test_get_lengths_works_with_words_and_characters(self):
         instance = IndexedTrueFalseInstance([[1, 2], [3, 1, 2]], True)
-        assert instance.get_lengths() == {'word_sequence_length': 2, 'word_character_length': 3}
+        assert instance.get_lengths() == {'max_sentence_length': 2, 'word_character_length': 3}
 
     def test_pad_word_sequence_handles_words_and_characters(self):
         instance = IndexedTrueFalseInstance([[1, 2], [3, 1, 2]], True)
         padded = instance.pad_word_sequence(instance.word_indices,
-                                            {'word_sequence_length': 3, 'word_character_length': 4})
+                                            {'max_sentence_length': 3, 'word_character_length': 4})
         assert padded == [[0, 0, 0, 0], [1, 2, 0, 0], [3, 1, 2, 0]]

--- a/tests/data/instances/true_false_instance_test.py
+++ b/tests/data/instances/true_false_instance_test.py
@@ -91,16 +91,16 @@ class TestTrueFalseInstance:
 class TestIndexedTrueFalseInstance(DeepQaTestCase):
     def test_get_lengths_returns_length_of_word_indices(self):
         instance = IndexedTrueFalseInstance([1, 2, 3, 4], True)
-        assert instance.get_lengths() == {'max_sentence_length': 4}
+        assert instance.get_lengths() == {'num_sentence_words': 4}
 
     def test_pad_adds_zeros_on_left(self):
         instance = IndexedTrueFalseInstance([1, 2, 3, 4], True)
-        instance.pad({'max_sentence_length': 5})
+        instance.pad({'num_sentence_words': 5})
         assert instance.word_indices == [0, 1, 2, 3, 4]
 
     def test_pad_truncates_from_right(self):
         instance = IndexedTrueFalseInstance([1, 2, 3, 4], True)
-        instance.pad({'max_sentence_length': 3})
+        instance.pad({'num_sentence_words': 3})
         assert instance.word_indices == [2, 3, 4]
 
     def test_as_training_data_produces_correct_numpy_arrays(self):

--- a/tests/data/instances/true_false_instance_test.py
+++ b/tests/data/instances/true_false_instance_test.py
@@ -91,16 +91,16 @@ class TestTrueFalseInstance:
 class TestIndexedTrueFalseInstance(DeepQaTestCase):
     def test_get_lengths_returns_length_of_word_indices(self):
         instance = IndexedTrueFalseInstance([1, 2, 3, 4], True)
-        assert instance.get_lengths() == {'word_sequence_length': 4}
+        assert instance.get_lengths() == {'max_sentence_length': 4}
 
     def test_pad_adds_zeros_on_left(self):
         instance = IndexedTrueFalseInstance([1, 2, 3, 4], True)
-        instance.pad({'word_sequence_length': 5})
+        instance.pad({'max_sentence_length': 5})
         assert instance.word_indices == [0, 1, 2, 3, 4]
 
     def test_pad_truncates_from_right(self):
         instance = IndexedTrueFalseInstance([1, 2, 3, 4], True)
-        instance.pad({'word_sequence_length': 3})
+        instance.pad({'max_sentence_length': 3})
         assert instance.word_indices == [2, 3, 4]
 
     def test_as_training_data_produces_correct_numpy_arrays(self):

--- a/tests/data/instances/tuple_inference_instance_test.py
+++ b/tests/data/instances/tuple_inference_instance_test.py
@@ -102,7 +102,7 @@ class TestTupleInferenceInstance(DeepQaTestCase):
         max_lengths = {'num_question_tuples': num_question_tuples,
                        'num_background_tuples': num_background_tuples,
                        'num_slots': num_slots,
-                       'max_sentence_length': slot_length,
+                       'num_sentence_words': slot_length,
                        'num_options': num_options}
         indexed.pad(max_lengths)
         assert len(indexed.answers_indexed) == num_options
@@ -122,7 +122,7 @@ class TestTupleInferenceInstance(DeepQaTestCase):
         max_lengths = {'num_question_tuples': 2,
                        'num_background_tuples': 3,
                        'num_slots': 2,
-                       'max_sentence_length': 2,
+                       'num_sentence_words': 2,
                        'num_options': 3}
         self.indexed_instance.pad(max_lengths)
 
@@ -161,7 +161,7 @@ class TestTupleInferenceInstance(DeepQaTestCase):
         max_lengths = {'num_question_tuples': 1,
                        'num_background_tuples': 1,
                        'num_slots': 2,
-                       'max_sentence_length': 2,
+                       'num_sentence_words': 2,
                        'num_options': 1,
                        'max_word_length': 3}
         indexed.pad(max_lengths)

--- a/tests/data/instances/tuple_inference_instance_test.py
+++ b/tests/data/instances/tuple_inference_instance_test.py
@@ -163,7 +163,7 @@ class TestTupleInferenceInstance(DeepQaTestCase):
                        'num_slots': 2,
                        'max_sentence_length': 2,
                        'num_options': 1,
-                       'word_character_length': 3}
+                       'max_word_length': 3}
         indexed.pad(max_lengths)
         expected_indexed_tuple = [[[0, 0, 0], [a_word_index, a_index, 0]],
                                   [[a_word_index, a_index, 0], [sentence_index, s_index, e_index]]]

--- a/tests/data/instances/tuple_inference_instance_test.py
+++ b/tests/data/instances/tuple_inference_instance_test.py
@@ -163,7 +163,7 @@ class TestTupleInferenceInstance(DeepQaTestCase):
                        'num_slots': 2,
                        'num_sentence_words': 2,
                        'num_options': 1,
-                       'max_word_length': 3}
+                       'num_word_characters': 3}
         indexed.pad(max_lengths)
         expected_indexed_tuple = [[[0, 0, 0], [a_word_index, a_index, 0]],
                                   [[a_word_index, a_index, 0], [sentence_index, s_index, e_index]]]

--- a/tests/data/instances/tuple_inference_instance_test.py
+++ b/tests/data/instances/tuple_inference_instance_test.py
@@ -102,7 +102,7 @@ class TestTupleInferenceInstance(DeepQaTestCase):
         max_lengths = {'num_question_tuples': num_question_tuples,
                        'num_background_tuples': num_background_tuples,
                        'num_slots': num_slots,
-                       'word_sequence_length': slot_length,
+                       'max_sentence_length': slot_length,
                        'num_options': num_options}
         indexed.pad(max_lengths)
         assert len(indexed.answers_indexed) == num_options
@@ -122,7 +122,7 @@ class TestTupleInferenceInstance(DeepQaTestCase):
         max_lengths = {'num_question_tuples': 2,
                        'num_background_tuples': 3,
                        'num_slots': 2,
-                       'word_sequence_length': 2,
+                       'max_sentence_length': 2,
                        'num_options': 3}
         self.indexed_instance.pad(max_lengths)
 
@@ -161,7 +161,7 @@ class TestTupleInferenceInstance(DeepQaTestCase):
         max_lengths = {'num_question_tuples': 1,
                        'num_background_tuples': 1,
                        'num_slots': 2,
-                       'word_sequence_length': 2,
+                       'max_sentence_length': 2,
                        'num_options': 1,
                        'word_character_length': 3}
         indexed.pad(max_lengths)

--- a/tests/data/instances/tuple_instance_test.py
+++ b/tests/data/instances/tuple_instance_test.py
@@ -29,21 +29,21 @@ class TestTupleInstance:
 class TestIndexedTupleInstance(DeepQaTestCase):
     def test_get_lengths_returns_length_of_longest_slot(self):
         instance = IndexedTupleInstance([[1, 2], [3, 4, 5], [6]], True)
-        assert instance.get_lengths() == {'word_sequence_length': 3, 'num_slots': 3}
+        assert instance.get_lengths() == {'max_sentence_length': 3, 'num_slots': 3}
 
     def test_pad_adds_zeros_on_all_slots(self):
         instance = IndexedTupleInstance([[1, 2], [3, 4, 5], [6]], True)
-        instance.pad({'word_sequence_length': 4, 'num_slots': 3})
+        instance.pad({'max_sentence_length': 4, 'num_slots': 3})
         assert instance.word_indices == [[0, 0, 1, 2], [0, 3, 4, 5], [0, 0, 0, 6]]
 
     def test_pad_slots_concatenates_at_end(self):
         instance = IndexedTupleInstance([[1, 2], [3, 4], [5, 6], [7, 8]], True)
-        instance.pad({'word_sequence_length': 4, 'num_slots': 3})
+        instance.pad({'max_sentence_length': 4, 'num_slots': 3})
         assert instance.word_indices == [[0, 0, 1, 2], [0, 0, 3, 4], [5, 6, 7, 8]]
 
     def test_pad_adjusts_slots_before_length(self):
         instance = IndexedTupleInstance([[1, 2], [3, 4], [5, 6], [7, 8]], True)
-        instance.pad({'word_sequence_length': 2, 'num_slots': 3})
+        instance.pad({'max_sentence_length': 2, 'num_slots': 3})
         print(instance.word_indices)
         assert instance.word_indices == [[1, 2], [3, 4], [7, 8]]
 

--- a/tests/data/instances/tuple_instance_test.py
+++ b/tests/data/instances/tuple_instance_test.py
@@ -29,21 +29,21 @@ class TestTupleInstance:
 class TestIndexedTupleInstance(DeepQaTestCase):
     def test_get_lengths_returns_length_of_longest_slot(self):
         instance = IndexedTupleInstance([[1, 2], [3, 4, 5], [6]], True)
-        assert instance.get_lengths() == {'max_sentence_length': 3, 'num_slots': 3}
+        assert instance.get_lengths() == {'num_sentence_words': 3, 'num_slots': 3}
 
     def test_pad_adds_zeros_on_all_slots(self):
         instance = IndexedTupleInstance([[1, 2], [3, 4, 5], [6]], True)
-        instance.pad({'max_sentence_length': 4, 'num_slots': 3})
+        instance.pad({'num_sentence_words': 4, 'num_slots': 3})
         assert instance.word_indices == [[0, 0, 1, 2], [0, 3, 4, 5], [0, 0, 0, 6]]
 
     def test_pad_slots_concatenates_at_end(self):
         instance = IndexedTupleInstance([[1, 2], [3, 4], [5, 6], [7, 8]], True)
-        instance.pad({'max_sentence_length': 4, 'num_slots': 3})
+        instance.pad({'num_sentence_words': 4, 'num_slots': 3})
         assert instance.word_indices == [[0, 0, 1, 2], [0, 0, 3, 4], [5, 6, 7, 8]]
 
     def test_pad_adjusts_slots_before_length(self):
         instance = IndexedTupleInstance([[1, 2], [3, 4], [5, 6], [7, 8]], True)
-        instance.pad({'max_sentence_length': 2, 'num_slots': 3})
+        instance.pad({'num_sentence_words': 2, 'num_slots': 3})
         print(instance.word_indices)
         assert instance.word_indices == [[1, 2], [3, 4], [7, 8]]
 

--- a/tests/models/memory_networks/differentiable_search_test.py
+++ b/tests/models/memory_networks/differentiable_search_test.py
@@ -27,7 +27,7 @@ class TestDifferentiableSearchMemoryNetwork(DeepQaTestCase):
         args = {
                 'corpus_path': self.corpus_path,
                 'model_serialization_prefix': './',
-                'max_sentence_length': 3,
+                'num_sentence_words': 3,
                 }
         model = self.get_model(DifferentiableSearchMemoryNetwork, args)
         model.encoder_model = FakeEncoder()
@@ -37,11 +37,11 @@ class TestDifferentiableSearchMemoryNetwork(DeepQaTestCase):
         args = {
                 'corpus_path': self.corpus_path,
                 'model_serialization_prefix': './',
-                'max_sentence_length': 5,
+                'num_sentence_words': 5,
                 }
         model = self.get_model(DifferentiableSearchMemoryNetwork, args)
         model.encoder_model = FakeEncoder()
         model._initialize_lsh()
-        model.max_sentence_length = 5
+        model.num_sentence_words = 5
         model.max_knowledge_length = 2
         model.get_nearest_neighbors(TrueFalseInstance("this is a sentence", True))

--- a/tests/models/memory_networks/memory_network_test.py
+++ b/tests/models/memory_networks/memory_network_test.py
@@ -24,7 +24,7 @@ class TestMemoryNetwork(DeepQaTestCase):
 
     def test_train_does_not_crash_with_cnn_encoder(self):
         args = {
-                'max_sentence_length': 5,
+                'num_sentence_words': 5,
                 'encoder': {'default': {'type': 'cnn',
                                         'ngram_filter_sizes': [2, 3],
                                         'num_filters': 5}}

--- a/tests/models/multiple_choice_qa/tuple_inference_model_test.py
+++ b/tests/models/multiple_choice_qa/tuple_inference_model_test.py
@@ -13,7 +13,7 @@ class TestTupleInferenceModel(DeepQaTestCase):
                 "num_question_tuples": 5,
                 "num_background_tuples": 5,
                 "num_tuple_slots": 4,
-                "max_sentence_length": 10,
+                "num_sentence_words": 10,
                 "num_answer_options": 4,
                 "save_models": True}
         solver = self.get_model(TupleInferenceModel, args)

--- a/tests/models/multiple_choice_qa/tuple_inference_model_test.py
+++ b/tests/models/multiple_choice_qa/tuple_inference_model_test.py
@@ -13,7 +13,7 @@ class TestTupleInferenceModel(DeepQaTestCase):
                 "num_question_tuples": 5,
                 "num_background_tuples": 5,
                 "num_tuple_slots": 4,
-                "word_sequence_length": 10,
+                "max_sentence_length": 10,
                 "num_answer_options": 4,
                 "save_models": True}
         solver = self.get_model(TupleInferenceModel, args)


### PR DESCRIPTION
(Wanted to do this before it fell off my radar). This PR renames the canonical keys we use in the `max_length` dictionary (used to set the max lengths for padding) to match the class variables in `text_trainer`.

Fairly trivial PR, i just ran:
```
grep -rl "word_sequence_length" . | xargs sed -i 's/word_sequence_length/max_sentence_length/g'
grep -rl "word_character_length" . | xargs sed -i 's/word_character_length/max_word_length/g'
```
with a `git commit` after each.

renaming `_get_word_sequence_lengths` to `_get_max_sentence_lengths` was unintended, but I kind of like the new name --- thoughts? it should actually probably get a new name altogether since you can get both the `max_sentence_length` and the `max_word_length` from it...