### PR TITLE
Switch time distributed

### DIFF
--- a/deep_qa/layers/tuple_matchers/word_overlap_tuple_matcher.py
+++ b/deep_qa/layers/tuple_matchers/word_overlap_tuple_matcher.py
@@ -106,6 +106,11 @@ class WordOverlapTupleMatcher(Layer):
         mask = K.any(input1, axis=[1, 2]) * K.any(input2, axis=[1, 2])
         return K.expand_dims(mask)
 
+    def get_output_mask_shape_for(self, input_shape):  # pylint: disable=no-self-use
+        # input_shape is [(batch_size, num_slots, num_slot_words_t1), (batch_size, num_slots, num_slot_words_t2)]
+        mask_shape = (input_shape[0][0], 1)
+        return mask_shape
+
     def call(self, x, mask=None):
         tuple1_input, tuple2_input = x      # tuple1 shape: (batch size, num_slots, num_slot_words_t1)
                                             # tuple2 shape: (batch size, num_slots, num_slot_words_t2)

--- a/deep_qa/layers/wrappers/time_distributed_with_mask.py
+++ b/deep_qa/layers/wrappers/time_distributed_with_mask.py
@@ -20,8 +20,6 @@ class TimeDistributedWithMask(TimeDistributed):
         if not isinstance(input_mask, list):
             x = [x]
             input_mask = [input_mask]
-        if not any([mask is not None for mask in input_mask]):
-            return None
         timesteps = K.int_shape(x[0])[1]
         input_shape = [K.int_shape(x_i) for x_i in x]
         if len(x) == 1:

--- a/deep_qa/models/multiple_choice_qa/tuple_inference.py
+++ b/deep_qa/models/multiple_choice_qa/tuple_inference.py
@@ -8,9 +8,8 @@ from deep_qa.layers.tuple_matchers.word_overlap_tuple_matcher import WordOverlap
 from deep_qa.layers.tuple_matchers import tuple_matchers
 from ...layers.attention.masked_softmax import MaskedSoftmax
 from ...layers.backend.repeat import Repeat
-from ...layers.backend.squeeze import Squeeze
 from ...layers.noisy_or import NoisyOr
-from ...layers.wrappers.time_distributed import TimeDistributed
+from ...layers.wrappers.time_distributed_with_mask import TimeDistributedWithMask
 from ...training.models import DeepQaModel
 from ...training.text_trainer import TextTrainer
 from ...common.params import get_choice_with_default
@@ -69,7 +68,8 @@ class TupleInferenceModel(TextTrainer):
             # These TimeDistributed wrappers correspond to distributing across each of num_options,
             # num_question_tuples, and num_background_tuples.
             match_layer = tuple_matcher_class(**tuple_matcher_params)
-            self.tuple_matcher = TimeDistributed(TimeDistributed(TimeDistributed(match_layer)))
+            self.tuple_matcher = TimeDistributedWithMask(
+                    TimeDistributedWithMask(TimeDistributedWithMask(match_layer)))
         else:
             self.tuple_matcher = tuple_matcher_class(self, tuple_matcher_params)
         super(TupleInferenceModel, self).__init__(params)
@@ -89,7 +89,7 @@ class TupleInferenceModel(TextTrainer):
         custom_objects['MaskedSoftmax'] = MaskedSoftmax
         custom_objects['NoisyOr'] = NoisyOr
         custom_objects['Repeat'] = Repeat
-        custom_objects['Squeeze'] = Squeeze
+        custom_objects['TimeDistributedWithMask'] = TimeDistributedWithMask
         return custom_objects
 
     @overrides

--- a/tests/layers/wrappers/time_distributed_with_mask_test.py
+++ b/tests/layers/wrappers/time_distributed_with_mask_test.py
@@ -9,6 +9,7 @@ from deep_qa.layers.wrappers.encoder_wrapper import EncoderWrapper
 from deep_qa.layers.wrappers.time_distributed_with_mask import TimeDistributedWithMask
 from deep_qa.layers.wrappers.output_mask import OutputMask
 from deep_qa.layers.tuple_matchers.slot_similarity_tuple_matcher import SlotSimilarityTupleMatcher
+from deep_qa.layers.tuple_matchers.word_overlap_tuple_matcher import WordOverlapTupleMatcher
 from deep_qa.training.models import DeepQaModel
 from ...common.test_case import DeepQaTestCase
 
@@ -34,6 +35,43 @@ class TestTimeDistributedWithMask(DeepQaTestCase):
                 SlotSimilarityTupleMatcher({"type": "cosine_similarity"})))
 
         time_distributed_output = time_distributed([encoded_tuple, encoded_tuple_2])
+        mask_output = OutputMask()(time_distributed_output)
+        model = DeepQaModel(input=[tuple_input, tuple_input_2], output=mask_output)
+        zeros = [0, 0, 0, 0, 0]
+        non_zeros = [1, 1, 1, 1, 1]
+        # shape: (batch size, num_options, num_tuples, num_slots, num_words), or (1, 2, 3, 4, 5)
+        tuples1 = numpy.asarray([[[[zeros, zeros, zeros, zeros],
+                                   [non_zeros, zeros, zeros, zeros],
+                                   [non_zeros, non_zeros, zeros, zeros]],
+                                  [[non_zeros, non_zeros, zeros, zeros],
+                                   [non_zeros, zeros, zeros, zeros],
+                                   [zeros, zeros, zeros, zeros]]]])
+        tuples2 = numpy.asarray([[[[non_zeros, zeros, zeros, zeros],
+                                   [non_zeros, zeros, zeros, zeros],
+                                   [zeros, zeros, zeros, zeros]],
+                                  [[non_zeros, non_zeros, zeros, zeros],
+                                   [non_zeros, zeros, zeros, zeros],
+                                   [non_zeros, zeros, zeros, zeros]]]])
+        actual_mask = model.predict([tuples1, tuples2])
+        expected_mask = numpy.asarray([[[0, 1, 0], [1, 1, 0]]]) # shape: (batch size, num_options, num_tuples)
+        assert actual_mask.shape == (1, 2, 3)
+        numpy.testing.assert_array_almost_equal(expected_mask, actual_mask)
+
+    def test_returns_masks_if_no_input_mask(self):
+        # We'll use the SlotSimilarityTupleMatcher to test this, because it takes two masked
+        # inputs.  Here we're using an input of shape (batch_size, num_options, num_tuples,
+        # num_slots, num_words).
+        tuple_input = Input(shape=(2, 3, 4, 5), dtype='int32')
+        tuple_input_2 = Input(shape=(2, 3, 4, 5), dtype='int32')
+        # shape is (batch_size, num_options, num_tuples, num_slots, num_words)
+
+        # Shape of input to the tuple matcher is [(batch size, 2, 3, 4, 5), (batch size, 2, 3, 4, 5)]
+        # Shape of input_mask to the tuple matcher is  [None, None]
+        # Expected output mask shape (batch_size, 2, 3)
+        time_distributed = TimeDistributedWithMask(TimeDistributedWithMask(
+                WordOverlapTupleMatcher()))
+
+        time_distributed_output = time_distributed([tuple_input, tuple_input_2])
         mask_output = OutputMask()(time_distributed_output)
         model = DeepQaModel(input=[tuple_input, tuple_input_2], output=mask_output)
         zeros = [0, 0, 0, 0, 0]


### PR DESCRIPTION
As we discussed, switches to using TDWM for word_overlap matcher, also adds test to ensure TDWM passes out a correct mask even if no input masks provided (and code removed to make it work).