### PR TITLE
Update requirements.txt for tensorflow-gpu

### DIFF
--- a/build_tools/travis/test_script.sh
+++ b/build_tools/travis/test_script.sh
@@ -12,7 +12,7 @@ python --version
 
 run_tests() {
     if [[ "$KERAS_BACKEND" == "tensorflow" ]]; then
-        KERAS_BACKEND=tensorflow py.test -v --cov=deep_qa --durations=20
+        KERAS_BACKEND=tensorflow CUDA_VISIBLE_DEVICES="" py.test -v --cov=deep_qa --durations=20
     else
         KERAS_BACKEND=theano OMP_NUM_THREADS=4 THEANO_FLAGS='optimizer=fast_compile,openmp=True' py.test -v --cov=deep_qa --durations=20
     fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,9 +16,9 @@ theano
 # If you want to use the GPU version, you will also need Nvidia's CUDA toolkit and cuDNN:
 # https://developer.nvidia.com/cuda-downloads
 # https://developer.nvidia.com/cudnn
-# Note that if you want to use the GPU version, you have to `pip uninstall tensorflow`
-# and `pip install tensorflow-gpu`, since both cannot coexist. 
-tensorflow==0.12.1
+# Note that if you want to use the CPU version, you have to `pip uninstall tensorflow-gpu`
+# and `pip install tensorflow`, since both cannot coexist. 
+tensorflow-gpu==0.12.1
 
 # These are for running this as an Aristo solver using gRPC.
 grpcio


### PR DESCRIPTION
tensorflow-gpu seems to have the ability to run CPU code...so I think it is a reasonable default.

The main reason i made this change is because setting up the solver to run on docker installs from requirements.txt, and we probably want the GPU version on there.