### PR TITLE
fix BiDAF set_max_lengths_from_model

### DIFF
--- a/deep_qa/models/reading_comprehension/bidirectional_attention.py
+++ b/deep_qa/models/reading_comprehension/bidirectional_attention.py
@@ -223,7 +223,7 @@ class BidirectionalAttentionFlow(TextTrainer):
         # the passage input or the question input is arbitrary, as the
         # two word lengths are guaranteed to be the same and BiDAF ignores
         # self.num_sentence_words.
-        self.set_text_lengths_from_model_input(self.model.get_input_shape_at(0)[1][2:])
+        self.set_text_lengths_from_model_input(self.model.get_input_shape_at(0)[1][1:])
 
     @classmethod
     def _get_custom_objects(cls):

--- a/deep_qa/training/trainer.py
+++ b/deep_qa/training/trainer.py
@@ -222,8 +222,8 @@ class Trainer:
         """
         raise NotImplementedError
 
-    def prepare_data(self, train_files, max_training_instances,
-                     validation_files, update_data_indexer=True):
+    def prepare_data(self, train_files, max_training_instances=None,
+                     validation_files=None, update_data_indexer=True):
         logger.info("Getting training data")
         training_dataset = self._load_dataset_from_files(train_files)
         if max_training_instances is not None:

--- a/tests/common/test_case.py
+++ b/tests/common/test_case.py
@@ -242,7 +242,7 @@ class DeepQaTestCase(TestCase):
 
     def write_span_prediction_files(self):
         with codecs.open(self.VALIDATION_FILE, 'w', 'utf-8') as train_file:
-            train_file.write('1\tquestion 1\tpassage with answer\t13,18\n')
+            train_file.write('1\tquestion 1 with extra words\tpassage with answer and a reallylongword\t13,18\n')
         with codecs.open(self.TRAIN_FILE, 'w', 'utf-8') as train_file:
             train_file.write('1\tquestion 1\tpassage1 with answer1\t14,20\n')
             train_file.write('2\tquestion 2\tpassage2 with answer2\t0,8\n')

--- a/tests/models/reading_comprehension/bidirectional_attention_test.py
+++ b/tests/models/reading_comprehension/bidirectional_attention_test.py
@@ -25,6 +25,14 @@ class TestBidirectionalAttentionFlow(DeepQaTestCase):
         assert_allclose(model.model.predict(model.__dict__["validation_input"]),
                         loaded_model.model.predict(model.__dict__["validation_input"]))
 
+        # We should get the same result if we index the data from the
+        # original model and the loaded model.
+        indexed_val_data, _ = loaded_model.prepare_data(model.__dict__["validation_files"],
+                                                        update_data_indexer=False)
+        _, indexed_validation_input, indexed_validation_labels = indexed_val_data
+        assert_allclose(model.model.predict(model.__dict__["validation_input"]),
+                        loaded_model.model.predict(indexed_validation_input))
+
         # now fit both models on some more data, and ensure that we get the same results.
         self.write_additional_span_prediction_files()
         # pylint: disable=unused-variable

--- a/tests/models/reading_comprehension/bidirectional_attention_test.py
+++ b/tests/models/reading_comprehension/bidirectional_attention_test.py
@@ -27,9 +27,9 @@ class TestBidirectionalAttentionFlow(DeepQaTestCase):
 
         # We should get the same result if we index the data from the
         # original model and the loaded model.
-        indexed_validation_input, _ = loaded_model._prepare_data(
-            model.__dict__["validation_dataset"],
-            for_train=False)
+        indexed_validation_input, _ = loaded_model._prepare_data( # pylint: disable=protected-access
+                model.__dict__["validation_dataset"],
+                for_train=False)
         assert_allclose(model.model.predict(model.__dict__["validation_input"]),
                         loaded_model.model.predict(indexed_validation_input))
 

--- a/tests/models/reading_comprehension/bidirectional_attention_test.py
+++ b/tests/models/reading_comprehension/bidirectional_attention_test.py
@@ -27,9 +27,9 @@ class TestBidirectionalAttentionFlow(DeepQaTestCase):
 
         # We should get the same result if we index the data from the
         # original model and the loaded model.
-        indexed_val_data, _ = loaded_model.prepare_data(model.__dict__["validation_files"],
-                                                        update_data_indexer=False)
-        _, indexed_validation_input, indexed_validation_labels = indexed_val_data
+        indexed_validation_input, _ = loaded_model._prepare_data(
+            model.__dict__["validation_dataset"],
+            for_train=False)
         assert_allclose(model.model.predict(model.__dict__["validation_input"]),
                         loaded_model.model.predict(indexed_validation_input))
 


### PR DESCRIPTION
This fixes an error in the `_set_max_lengths_from_model` function. I think it clearly makes sense to pass `self.model.get_input_shape_at(0)[1][1:]`, considering the words are at `self.model.get_input_shape_at(0)[1][1]`.

I'd like to add a non-regression test to make sure that this issue doesn't come up again, but i'm not sure what sort of examples would be appropriate. thoughts?