### PR TITLE
add custom score_instance function for BiDAF to return start/end span indices

### DIFF
--- a/deep_qa/models/reading_comprehension/bidirectional_attention.py
+++ b/deep_qa/models/reading_comprehension/bidirectional_attention.py
@@ -236,6 +236,7 @@ class BidirectionalAttentionFlow(TextTrainer):
         custom_objects["WeightedSum"] = WeightedSum
         return custom_objects
 
+    @overrides
     def score_instance(self, instance: CharacterSpanInstance):
         inputs, _ = self._prepare_instance(instance)
         try:
@@ -246,7 +247,8 @@ class BidirectionalAttentionFlow(TextTrainer):
             print('Inputs were: ' + str(inputs))
             raise
 
-    def get_best_span(self, span_begin_probs, span_end_probs):
+    @staticmethod
+    def get_best_span(span_begin_probs, span_end_probs):
         max_span_probability = 0
         best_word_span = (0, 1)
         begin_span_argmax = 0

--- a/deep_qa/models/reading_comprehension/bidirectional_attention.py
+++ b/deep_qa/models/reading_comprehension/bidirectional_attention.py
@@ -235,3 +235,29 @@ class BidirectionalAttentionFlow(TextTrainer):
         custom_objects["Repeat"] = Repeat
         custom_objects["WeightedSum"] = WeightedSum
         return custom_objects
+
+    def score_instance(self, instance: CharacterSpanInstance):
+        inputs, _ = self._prepare_instance(instance)
+        try:
+            span_begin_probs, span_end_probs = self.model.predict(inputs)
+            best_span, best_span_prob = self.get_best_span(span_begin_probs,
+                                                           span_end_probs)
+        except:
+            print('Inputs were: ' + str(inputs))
+            raise
+
+    def get_best_span(self, span_begin_probs, span_end_probs):
+        max_span_probability = 0
+        best_word_span = (0, 1)
+        begin_span_argmax = 0
+        for j in range(len(span_begin_probs)):
+            val1 = span_begin_probs[begin_span_argmax]
+            if val1 < span_begin_probs[j]:
+                val1 = span_begin_probs[j]
+                begin_span_argmax = j
+
+            val2 = span_end_probs[j]
+            if val1 * val2 > max_span_probability:
+                best_word_span = (begin_span_argmax, j)
+                max_span_probability = val1 * val2
+        return (best_word_span[0], best_word_span[1] + 1)

--- a/deep_qa/models/reading_comprehension/bidirectional_attention.py
+++ b/deep_qa/models/reading_comprehension/bidirectional_attention.py
@@ -253,7 +253,7 @@ class BidirectionalAttentionFlow(TextTrainer):
         max_span_probability = 0
         best_word_span = (0, 1)
         begin_span_argmax = 0
-        for j in range(len(span_begin_probs)):
+        for j, _ in enumerate(span_begin_probs):
             val1 = span_begin_probs[begin_span_argmax]
             if val1 < span_begin_probs[j]:
                 val1 = span_begin_probs[j]

--- a/deep_qa/models/reading_comprehension/bidirectional_attention.py
+++ b/deep_qa/models/reading_comprehension/bidirectional_attention.py
@@ -241,8 +241,9 @@ class BidirectionalAttentionFlow(TextTrainer):
         inputs, _ = self._prepare_instance(instance)
         try:
             span_begin_probs, span_end_probs = self.model.predict(inputs)
-            best_span, best_span_prob = self.get_best_span(span_begin_probs,
-                                                           span_end_probs)
+            span_indices = self.get_best_span(span_begin_probs,
+                                              span_end_probs)
+            return span_indices
         except:
             print('Inputs were: ' + str(inputs))
             raise
@@ -262,4 +263,7 @@ class BidirectionalAttentionFlow(TextTrainer):
             if val1 * val2 > max_span_probability:
                 best_word_span = (begin_span_argmax, j)
                 max_span_probability = val1 * val2
+        # Note that this function returns an exclusive span
+        # end, while we assume that it was trained in an
+        # inclusive span end setting.
         return (best_word_span[0], best_word_span[1] + 1)

--- a/tests/models/reading_comprehension/bidirectional_attention_test.py
+++ b/tests/models/reading_comprehension/bidirectional_attention_test.py
@@ -52,11 +52,15 @@ class TestBidirectionalAttentionFlow(DeepQaTestCase):
         #                 loaded_model.model.predict(validation_input))
 
     def test_get_best_span(self):
-        # Note that the best span cannot be (1, 1) since even though
+        # Note that the best span cannot be (1, 1) (remember that the end span index)
+        # is exclusive) since even though
         # 0.3 * 0.5 is the greatest value, the end span index is constrained
         # to occur after the begin span index.
         span_begin_probs = numpy.array([0.1, 0.3, 0.05, 0.3, 0.25])
         span_end_probs = numpy.array([0.5, 0.1, 0.2, 0.05, 0.15])
         begin_end_idxs = BidirectionalAttentionFlow.get_best_span(span_begin_probs,
                                                                   span_end_probs)
+        # Note that while the max is 0.3 (index 1 of start) * 0.2 (index 2 of start),
+        # the final best span returned is actually (1, 3) because we treat the
+        # end span as being exclusive.
         assert begin_end_idxs == (1, 3)

--- a/tests/models/reading_comprehension/bidirectional_attention_test.py
+++ b/tests/models/reading_comprehension/bidirectional_attention_test.py
@@ -1,4 +1,5 @@
 # pylint: disable=no-self-use,invalid-name
+import numpy
 from numpy.testing import assert_allclose
 
 from deep_qa.models.reading_comprehension.bidirectional_attention import BidirectionalAttentionFlow
@@ -41,3 +42,13 @@ class TestBidirectionalAttentionFlow(DeepQaTestCase):
         # TODO(matt): fix the randomness that occurs here.
         # assert_allclose(model.model.predict(validation_input),
         #                 loaded_model.model.predict(validation_input))
+
+    def test_get_best_span(self):
+        # Note that the best span cannot be (1, 1) since even though
+        # 0.3 * 0.5 is the greatest value, the end span index is constrained
+        # to occur after the begin span index.
+        span_begin_probs = numpy.array([0.1, 0.3, 0.05, 0.3, 0.25])
+        span_end_probs = numpy.array([0.5, 0.1, 0.2, 0.05, 0.15])
+        begin_end_idxs = BidirectionalAttentionFlow.get_best_span(span_begin_probs,
+                                                                  span_end_probs)
+        assert begin_end_idxs == (1, 3)


### PR DESCRIPTION
This PR enables us to directly get the most likely span begin/end instance from BiDAF for use in our solver server.