### PR TITLE
make BiDAF get_best_span support higher-order input

### DIFF
--- a/deep_qa/models/reading_comprehension/bidirectional_attention.py
+++ b/deep_qa/models/reading_comprehension/bidirectional_attention.py
@@ -250,6 +250,14 @@ class BidirectionalAttentionFlow(TextTrainer):
 
     @staticmethod
     def get_best_span(span_begin_probs, span_end_probs):
+        if len(span_begin_probs.shape) > 2 or len(span_end_probs.shape) > 2:
+            raise ValueError("Input shapes must be (,X) or (1, X)")
+        if len(span_begin_probs.shape) == 2:
+            assert span_begin_probs.shape[0] == 1, "2D input must have an initial dimension of 1"
+            span_begin_probs = span_begin_probs.flatten()
+        if len(span_end_probs.shape) == 2:
+            assert span_end_probs.shape[0] == 1, "2D input must have an initial dimension of 1"
+            span_end_probs = span_end_probs.flatten()
         max_span_probability = 0
         best_word_span = (0, 1)
         begin_span_argmax = 0

--- a/deep_qa/models/reading_comprehension/bidirectional_attention.py
+++ b/deep_qa/models/reading_comprehension/bidirectional_attention.py
@@ -251,7 +251,7 @@ class BidirectionalAttentionFlow(TextTrainer):
     @staticmethod
     def get_best_span(span_begin_probs, span_end_probs):
         if len(span_begin_probs.shape) > 2 or len(span_end_probs.shape) > 2:
-            raise ValueError("Input shapes must be (,X) or (1, X)")
+            raise ValueError("Input shapes must be (X,) or (1,X)")
         if len(span_begin_probs.shape) == 2:
             assert span_begin_probs.shape[0] == 1, "2D input must have an initial dimension of 1"
             span_begin_probs = span_begin_probs.flatten()

--- a/tests/models/reading_comprehension/bidirectional_attention_test.py
+++ b/tests/models/reading_comprehension/bidirectional_attention_test.py
@@ -64,3 +64,14 @@ class TestBidirectionalAttentionFlow(DeepQaTestCase):
         # the final best span returned is actually (1, 3) because we treat the
         # end span as being exclusive.
         assert begin_end_idxs == (1, 3)
+
+        # test higher-order input
+        span_begin_probs = numpy.array([[0.1, 0.3, 0.05, 0.3, 0.25]])
+        span_end_probs = numpy.array([[0.5, 0.1, 0.2, 0.05, 0.15]])
+        begin_end_idxs = BidirectionalAttentionFlow.get_best_span(span_begin_probs,
+                                                                  span_end_probs)
+        # Note that while the max is 0.3 (index 1 of start) * 0.2 (index 2 of start),
+        # the final best span returned is actually (1, 3) because we treat the
+        # end span as being exclusive.
+        assert begin_end_idxs == (1, 3)
+

--- a/tests/models/reading_comprehension/bidirectional_attention_test.py
+++ b/tests/models/reading_comprehension/bidirectional_attention_test.py
@@ -74,4 +74,3 @@ class TestBidirectionalAttentionFlow(DeepQaTestCase):
         # the final best span returned is actually (1, 3) because we treat the
         # end span as being exclusive.
         assert begin_end_idxs == (1, 3)
-


### PR DESCRIPTION
Previously, this wasn't working properly since `model.predict` outputs a np array of `shape (1,X)`, while I previously mistakenly assumed it was of `(X,)`.

So i fixed it and added tests.