### PR TITLE
fix travis miniconda cache path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: python
 cache:
   directories:
   - /home/travis/download
-  - /home/travis/miniconda
+  - /home/travis/miniconda3
   - /home/travis/.cache/pip
 
 env:

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -14,7 +14,7 @@ pushd .
 cd
 mkdir -p download
 cd download
-if [[ ! -d /home/travis/miniconda3 ]]
+if [[ ! -f /home/travis/miniconda3/bin/activate ]]
     then
     if [[ ! -f miniconda.sh ]]
         then

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -21,7 +21,7 @@ if [[ ! -f /home/travis/miniconda3/bin/activate ]]
             wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
                 -O miniconda.sh
     fi
-    chmod +x miniconda.sh && ./miniconda.sh -b
+    chmod +x miniconda.sh && ./miniconda.sh -b -f
     export PATH=/home/travis/miniconda3/bin:$PATH
     echo $PATH
     conda update --yes conda


### PR DESCRIPTION
I noticed that travisCI isnt actually caching our conda install due to a typo in this filepath.