### PR TITLE
Add collapsable code blocks, and use them in model train logs

### DIFF
--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -1,0 +1,12 @@
+.toggle .header {
+    display: block;
+    clear: both;
+}
+
+.toggle .header:after {
+    content: " ▼";
+}
+
+.toggle .header.open:after {
+    content: " ▲";
+}

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,0 +1,16 @@
+{% extends "!layout.html" %}
+
+{% set css_files = css_files + ["_static/custom.css"] %}
+
+{% block footer %}
+ <script type="text/javascript">
+    $(document).ready(function() {
+        $(".toggle > *").hide();
+        $(".toggle .header").show();
+        $(".toggle .header").click(function() {
+            $(this).parent().children().not(".header").toggle(400);
+            $(this).parent().children(".header").toggleClass("open");
+        })
+    });
+</script>
+{% endblock %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -43,7 +43,7 @@ extensions = ['sphinx.ext.autodoc',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-# templates_path = ['_templates']
+templates_path = ['_templates']
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
@@ -106,7 +106,7 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ['_static']
+html_static_path = ['_static']
 
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/doc/models/about_models.rst
+++ b/doc/models/about_models.rst
@@ -32,64 +32,70 @@ The `Attention Sum Reader
 Network is implemented in
 :mod:`~deep_qa.models.reading_comprehension.attention_sum_reader`.
 
-Here are the train logs::
+.. container:: toggle
 
-    Using Theano backend.
-    Using gpu device 0: Tesla K80 (CNMeM is disabled, cuDNN 5105)
-    /home/nelsonl/miniconda3/envs/deep_qa/lib/python3.5/site-packages/theano/sandbox/cuda/__init__.py:600: UserWarning: Your cuDNN version is more recent than the one Theano officially supports. If you see any problems, try updating Theano or downgrading cuDNN to version 5.
-      warnings.warn(warn)
-    2017-01-26 23:52:54,082 - INFO - deep_qa.common.checks - Keras version: 1.2.0
-    2017-01-26 23:52:54,082 - INFO - deep_qa.common.checks - Theano version: 0.8.2
-    2017-01-26 23:52:54,269 - INFO - __main__ - Training model
-    2017-01-26 23:52:54,270 - INFO - deep_qa.training.trainer - Running training (TextTrainer)
-    2017-01-26 23:52:54,270 - INFO - deep_qa.training.trainer - Getting training data
-    2017-01-26 23:52:58,914 - INFO - deep_qa.data.dataset - Finished reading dataset; label counts: [(0, 42399), (1, 44896), (2, 23832), (3, 11274), (4, 585)]
-    2017-01-26 23:58:07,539 - INFO - deep_qa.training.text_trainer - Indexing dataset
-    2017-01-27 00:03:28,722 - INFO - deep_qa.training.text_trainer - Padding dataset to lengths {'num_option_words': None, 'num_question_words': None, 'wod_sequence_length': None, 'num_options': None, 'num_passage_words': None}
-    2017-01-27 00:03:28,722 - INFO - deep_qa.data.dataset - Getting max lengths from instances
-    2017-01-27 00:03:29,714 - INFO - deep_qa.data.dataset - Instance max lengths: {'num_option_words': 68, 'num_question_words': 121, 'num_options': 5, 'nm_passage_words': 3090}
-    2017-01-27 00:03:29,714 - INFO - deep_qa.data.dataset - Now actually padding instances to length: {'num_option_words': 68, 'num_question_words': 121, num_options': 5, 'num_passage_words': 3090}
-    2017-01-27 00:05:40,054 - INFO - deep_qa.training.trainer - Getting validation data
-    2017-01-27 00:05:40,347 - INFO - deep_qa.data.dataset - Finished reading dataset; label counts: [(0, 3522), (1, 3429), (2, 1835), (3, 784), (4, 430)]
-    2017-01-27 00:05:40,348 - INFO - deep_qa.training.text_trainer - Indexing dataset
-    2017-01-27 00:06:02,773 - INFO - deep_qa.training.text_trainer - Padding dataset to lengths {'num_option_words': 68, 'num_question_words': 121, 'word_sequence_length': None, 'num_options': 5, 'num_passage_words': 3090}
-    2017-01-27 00:06:02,774 - INFO - deep_qa.data.dataset - Getting max lengths from instances
-    2017-01-27 00:06:02,851 - INFO - deep_qa.data.dataset - Instance max lengths: {'num_option_words': 8, 'num_question_words': 95, 'num_options': 5, 'num_passage_words': 2186}
-    2017-01-27 00:06:02,851 - INFO - deep_qa.data.dataset - Now actually padding instances to length: {'num_option_words': 68, 'num_question_words': 121, 'num_options': 5, 'num_passage_words': 3090}
-    2017-01-27 00:06:13,387 - INFO - deep_qa.training.trainer - Building the model
-    ____________________________________________________________________________________________________
-    Layer (type)                     Output Shape          Param #     Connected to
-    ====================================================================================================
-    document_input (InputLayer)      (None, 3090)          0
-    ____________________________________________________________________________________________________
-    question_input (InputLayer)      (None, 121)           0
-    ____________________________________________________________________________________________________
-    word_embedding (TimeDistributedE multiple              80112384    question_input[0][0]
-                                                                       document_input[0][0]
-    ____________________________________________________________________________________________________
-    bidirectional_1 (Bidirectional)  (None, 768)           1476864     word_embedding[0][0]
-    ____________________________________________________________________________________________________
-    bidirectional_2 (Bidirectional)  (None, 3090, 768)     1476864     word_embedding[1][0]
-    ____________________________________________________________________________________________________
-    question_document_softmax (Atten (None, 3090)          0           bidirectional_1[0][0]
-                                                                       bidirectional_2[0][0]
-    ____________________________________________________________________________________________________
-    options_input (InputLayer)       (None, 5, 68)         0
-    ____________________________________________________________________________________________________
-    options_probability_sum (OptionA (None, 5)             0           document_input[0][0]
-                                                                       question_document_softmax[0][0]
-                                                                       options_input[0][0]
-    ____________________________________________________________________________________________________
-    l1normalize_1 (L1Normalize)      (None, 5)             0           options_probability_sum[0][0]
-    ====================================================================================================
-    Total params: 83,066,112
-    Trainable params: 83,066,112
-    Non-trainable params: 0
-    ____________________________________________________________________________________________________
-    Train on 127786 samples, validate on 10000 samples
-    Epoch 1/5
-    127786/127786 [==============================] - 34850s - loss: 1.0131 - acc: 0.5290 - val_loss: 0.9776 - val_acc: 0.5624
-    Epoch 2/5
-    127786/127786 [==============================] - 34828s - loss: 0.6713 - acc: 0.7267 - val_loss: 1.0838 - val_acc: 0.5514
-    Epoch 3/5
-    127786/127786 [==============================] - 34835s - loss: 0.2720 - acc: 0.8996 - val_loss: 1.4446 - val_acc: 0.5335
+    .. container:: header
+
+        **Press to show/hide train logs**
+
+    Train Logs::
+
+        Using Theano backend.
+        Using gpu device 0: Tesla K80 (CNMeM is disabled, cuDNN 5105)
+        /home/nelsonl/miniconda3/envs/deep_qa/lib/python3.5/site-packages/theano/sandbox/cuda/__init__.py:600: UserWarning: Your cuDNN version is more recent than the one Theano officially supports. If you see any problems, try updating Theano or downgrading cuDNN to version 5.
+          warnings.warn(warn)
+        2017-01-26 23:52:54,082 - INFO - deep_qa.common.checks - Keras version: 1.2.0
+        2017-01-26 23:52:54,082 - INFO - deep_qa.common.checks - Theano version: 0.8.2
+        2017-01-26 23:52:54,269 - INFO - __main__ - Training model
+        2017-01-26 23:52:54,270 - INFO - deep_qa.training.trainer - Running training (TextTrainer)
+        2017-01-26 23:52:54,270 - INFO - deep_qa.training.trainer - Getting training data
+        2017-01-26 23:52:58,914 - INFO - deep_qa.data.dataset - Finished reading dataset; label counts: [(0, 42399), (1, 44896), (2, 23832), (3, 11274), (4, 585)]
+        2017-01-26 23:58:07,539 - INFO - deep_qa.training.text_trainer - Indexing dataset
+        2017-01-27 00:03:28,722 - INFO - deep_qa.training.text_trainer - Padding dataset to lengths {'num_option_words': None, 'num_question_words': None, 'wod_sequence_length': None, 'num_options': None, 'num_passage_words': None}
+        2017-01-27 00:03:28,722 - INFO - deep_qa.data.dataset - Getting max lengths from instances
+        2017-01-27 00:03:29,714 - INFO - deep_qa.data.dataset - Instance max lengths: {'num_option_words': 68, 'num_question_words': 121, 'num_options': 5, 'nm_passage_words': 3090}
+        2017-01-27 00:03:29,714 - INFO - deep_qa.data.dataset - Now actually padding instances to length: {'num_option_words': 68, 'num_question_words': 121, num_options': 5, 'num_passage_words': 3090}
+        2017-01-27 00:05:40,054 - INFO - deep_qa.training.trainer - Getting validation data
+        2017-01-27 00:05:40,347 - INFO - deep_qa.data.dataset - Finished reading dataset; label counts: [(0, 3522), (1, 3429), (2, 1835), (3, 784), (4, 430)]
+        2017-01-27 00:05:40,348 - INFO - deep_qa.training.text_trainer - Indexing dataset
+        2017-01-27 00:06:02,773 - INFO - deep_qa.training.text_trainer - Padding dataset to lengths {'num_option_words': 68, 'num_question_words': 121, 'word_sequence_length': None, 'num_options': 5, 'num_passage_words': 3090}
+        2017-01-27 00:06:02,774 - INFO - deep_qa.data.dataset - Getting max lengths from instances
+        2017-01-27 00:06:02,851 - INFO - deep_qa.data.dataset - Instance max lengths: {'num_option_words': 8, 'num_question_words': 95, 'num_options': 5, 'num_passage_words': 2186}
+        2017-01-27 00:06:02,851 - INFO - deep_qa.data.dataset - Now actually padding instances to length: {'num_option_words': 68, 'num_question_words': 121, 'num_options': 5, 'num_passage_words': 3090}
+        2017-01-27 00:06:13,387 - INFO - deep_qa.training.trainer - Building the model
+        ____________________________________________________________________________________________________
+        Layer (type)                     Output Shape          Param #     Connected to
+        ====================================================================================================
+        document_input (InputLayer)      (None, 3090)          0
+        ____________________________________________________________________________________________________
+        question_input (InputLayer)      (None, 121)           0
+        ____________________________________________________________________________________________________
+        word_embedding (TimeDistributedE multiple              80112384    question_input[0][0]
+                                                                           document_input[0][0]
+        ____________________________________________________________________________________________________
+        bidirectional_1 (Bidirectional)  (None, 768)           1476864     word_embedding[0][0]
+        ____________________________________________________________________________________________________
+        bidirectional_2 (Bidirectional)  (None, 3090, 768)     1476864     word_embedding[1][0]
+        ____________________________________________________________________________________________________
+        question_document_softmax (Atten (None, 3090)          0           bidirectional_1[0][0]
+                                                                           bidirectional_2[0][0]
+        ____________________________________________________________________________________________________
+        options_input (InputLayer)       (None, 5, 68)         0
+        ____________________________________________________________________________________________________
+        options_probability_sum (OptionA (None, 5)             0           document_input[0][0]
+                                                                           question_document_softmax[0][0]
+                                                                           options_input[0][0]
+        ____________________________________________________________________________________________________
+        l1normalize_1 (L1Normalize)      (None, 5)             0           options_probability_sum[0][0]
+        ====================================================================================================
+        Total params: 83,066,112
+        Trainable params: 83,066,112
+        Non-trainable params: 0
+        ____________________________________________________________________________________________________
+        Train on 127786 samples, validate on 10000 samples
+        Epoch 1/5
+        127786/127786 [==============================] - 34850s - loss: 1.0131 - acc: 0.5290 - val_loss: 0.9776 - val_acc: 0.5624
+        Epoch 2/5
+        127786/127786 [==============================] - 34828s - loss: 0.6713 - acc: 0.7267 - val_loss: 1.0838 - val_acc: 0.5514
+        Epoch 3/5
+        127786/127786 [==============================] - 34835s - loss: 0.2720 - acc: 0.8996 - val_loss: 1.4446 - val_acc: 0.5335


### PR DESCRIPTION
Figured out how to get collapsable code blocks to work by overriding the template, and then reinserting it (with the `{{ super() }}`), thanks for the helpful link @matt-gardner.

