### PR TITLE
Stack seq2seq encoders to give sentence selector more depth

### DIFF
--- a/deep_qa/layers/wrappers/encoder_wrapper.py
+++ b/deep_qa/layers/wrappers/encoder_wrapper.py
@@ -12,6 +12,12 @@ class EncoderWrapper(TimeDistributed):
     masked (because we padded the number of sentences, for instance).  In this case, we just want
     to mask the entire sequence.  EncoderWrapper returns a mask with the same dimension as the
     input sequences, where sequences are masked if _all_ of their words were masked.
+
+    Notes
+    -----
+    For seq2seq encoders, one should use either ``TimeDistributed`` or
+    ``TimeDistributedWithMask`` since ``EncoderWrapper`` reduces the dimensionality
+    of the input mask.
     '''
     def compute_mask(self, x, input_mask=None):
         # pylint: disable=unused-argument

--- a/deep_qa/models/sentence_selection/siamese_sentence_selector.py
+++ b/deep_qa/models/sentence_selection/siamese_sentence_selector.py
@@ -24,13 +24,16 @@ class SiameseSentenceSelector(TextTrainer):
 
     Parameters
     ----------
-    num_seq2seq_layers : int, optional (default: ``2``)
+    num_hidden_seq2seq_layers : int, optional (default: ``2``)
         We use a few stacked biLSTMs (or similar), to give the model some
         depth.  This parameter controls how many deep layers we should use.
 
+    share_hidden_seq2seq_layers : bool, optional (default: ``False``)
+        Whether or not to encode the sentences and the question with the same
+        hidden seq2seq layers, or have different ones for each.
     """
     def __init__(self, params: Dict[str, Any]):
-        self.num_seq2seq_layers = params.pop('num_hidden_seq2seq_layers', 2)
+        self.num_hidden_seq2seq_layers = params.pop('num_hidden_seq2seq_layers', 2)
         self.share_hidden_seq2seq_layers = params.pop('share_hidden_seq2seq_layers', False)
         self.num_question_words = params.pop('num_question_words', None)
         self.num_sentences = params.pop('num_sentences', None)
@@ -68,7 +71,7 @@ class SiameseSentenceSelector(TextTrainer):
 
         # We encode the question embedding with some more seq2seq layers
         modeled_question = question_embedding
-        for i in range(self.num_seq2seq_layers):
+        for i in range(self.num_hidden_seq2seq_layers):
             if self.share_hidden_seq2seq_layers:
                 seq2seq_encoder_name = "seq2seq_{}".format(i)
             else:
@@ -80,7 +83,7 @@ class SiameseSentenceSelector(TextTrainer):
 
         # We encode the sentence embedding with some more seq2seq layers
         modeled_sentence = sentences_embedding
-        for i in range(self.num_seq2seq_layers):
+        for i in range(self.num_hidden_seq2seq_layers):
             if self.share_hidden_seq2seq_layers:
                 seq2seq_encoder_name = "seq2seq_{}".format(i)
             else:

--- a/deep_qa/models/sentence_selection/siamese_sentence_selector.py
+++ b/deep_qa/models/sentence_selection/siamese_sentence_selector.py
@@ -20,8 +20,16 @@ class SiameseSentenceSelector(TextTrainer):
 
     Note that in some cases, this may not be exactly "Siamese" because the
     question and sentences encoders can differ.
+
+    Parameters
+    ----------
+    num_seq2seq_layers : int, optional (default: ``2``)
+        We use a few stacked biLSTMs (or similar), to give the model some
+        depth.  This parameter controls how many deep layers we should use.
+
     """
     def __init__(self, params: Dict[str, Any]):
+        self.num_seq2seq_layers = params.pop('num_hidden_seq2seq_layers', 2)
         self.num_question_words = params.pop('num_question_words', None)
         self.num_sentences = params.pop('num_sentences', None)
         super(SiameseSentenceSelector, self).__init__(params)
@@ -56,18 +64,36 @@ class SiameseSentenceSelector(TextTrainer):
         # shape: (batch size, num_sentences, num_sentence_words, embedding size)
         sentences_embedding = self._embed_input(sentences_input)
 
-        # We encode the question embeddings with some encoder.
+        # We encode the question embedding with some more seq2seq layers
+        modeled_question = question_embedding
+        for i in range(self.num_seq2seq_layers):
+            hidden_layer = self._get_seq2seq_encoder(name="question_seq2seq_{}".format(i),
+                                                     fallback_behavior="use default params")
+            # shape: (batch_size, num_question_words, seq2seq output dimension)
+            modeled_question = hidden_layer(modeled_question)
+
+        # We encode the sentence embedding with some more seq2seq layers
+        modeled_sentence = sentences_embedding
+        for i in range(self.num_seq2seq_layers):
+            hidden_layer = EncoderWrapper(
+                self._get_seq2seq_encoder(name="sentence_seq2seq_{}".format(i),
+                                          fallback_behavior="use default params"),
+                name="TimeDistributed_seq2seq_sentences_encoder")
+            # shape: (batch_size, num_question_words, seq2seq output dimension)
+            modeled_sentence = hidden_layer(modeled_sentence)
+
+        # We encode the modeled question with some encoder.
         question_encoder = self._get_encoder(name="question_encoder",
                                              fallback_behavior="use default encoder")
         # shape: (batch size, encoder_output_dimension)
-        encoded_question = question_encoder(question_embedding)
+        encoded_question = question_encoder(modeled_question)
 
-        # We encode the document embeddings with some encoder.
+        # We encode the modeled document with some encoder.
         sentences_encoder = EncoderWrapper(self._get_encoder(name="sentence_encoder",
                                                              fallback_behavior="use default encoder"),
                                            name="TimeDistributed_sentences_encoder")
         # shape: (batch size, num_sentences, encoder_output_dimension)
-        encoded_sentences = sentences_encoder(sentences_embedding)
+        encoded_sentences = sentences_encoder(modeled_sentence)
 
         # Here we use the Attention layer with the cosine similarity function
         # to get the cosine similarities of each sesntence with the question.

--- a/deep_qa/models/sentence_selection/siamese_sentence_selector.py
+++ b/deep_qa/models/sentence_selection/siamese_sentence_selector.py
@@ -77,9 +77,9 @@ class SiameseSentenceSelector(TextTrainer):
         modeled_sentence = sentences_embedding
         for i in range(self.num_seq2seq_layers):
             hidden_layer = TimeDistributed(
-                self._get_seq2seq_encoder(name="sentence_seq2seq_{}".format(i),
-                                          fallback_behavior="use default params"),
-                name="TimeDistributed_seq2seq_sentences_encoder_{}".format(i))
+                    self._get_seq2seq_encoder(name="sentence_seq2seq_{}".format(i),
+                                              fallback_behavior="use default params"),
+                    name="TimeDistributed_seq2seq_sentences_encoder_{}".format(i))
             # shape: (batch_size, num_question_words, seq2seq output dimension)
             modeled_sentence = hidden_layer(modeled_sentence)
 

--- a/deep_qa/models/sentence_selection/siamese_sentence_selector.py
+++ b/deep_qa/models/sentence_selection/siamese_sentence_selector.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict
 from overrides import overrides
 from keras.layers import Input
+from keras.layers.wrappers import TimeDistributed
 
 from ...data.instances.sentence_selection_instance import SentenceSelectionInstance
 from ...layers.attention.attention import Attention
@@ -75,10 +76,10 @@ class SiameseSentenceSelector(TextTrainer):
         # We encode the sentence embedding with some more seq2seq layers
         modeled_sentence = sentences_embedding
         for i in range(self.num_seq2seq_layers):
-            hidden_layer = EncoderWrapper(
+            hidden_layer = TimeDistributed(
                 self._get_seq2seq_encoder(name="sentence_seq2seq_{}".format(i),
                                           fallback_behavior="use default params"),
-                name="TimeDistributed_seq2seq_sentences_encoder")
+                name="TimeDistributed_seq2seq_sentences_encoder_{}".format(i))
             # shape: (batch_size, num_question_words, seq2seq output dimension)
             modeled_sentence = hidden_layer(modeled_sentence)
 

--- a/example_experiments/siamese_sentence_selector_squad.json
+++ b/example_experiments/siamese_sentence_selector_squad.json
@@ -1,7 +1,8 @@
 {
     "model_class": "SiameseSentenceSelector",
     "model_serialization_prefix": "models/sentence_selection/siamese_stacked",
-    "share_hidden_seq2seq_layers": True,
+    "share_hidden_seq2seq_layers": true,
+    "num_sentence_words": 40,
     "encoder": {
         "default": {
             "type": "bi_gru",
@@ -23,8 +24,8 @@
         "words": 100
     },
     "pretrained_embeddings_file": "/efs/data/dlfa/glove/glove.6B.100d.txt.gz",
-    "fine_tune_embeddings": False,
-    "project_embeddings": False,
+    "fine_tune_embeddings": false,
+    "project_embeddings": false,
     "optimizer": {
         "type": "adam"
     },

--- a/example_experiments/siamese_sentence_selector_squad.json
+++ b/example_experiments/siamese_sentence_selector_squad.json
@@ -1,6 +1,7 @@
 {
     "model_class": "SiameseSentenceSelector",
     "model_serialization_prefix": "models/sentence_selection/siamese_stacked",
+    "share_hidden_seq2seq_layers": True,
     "encoder": {
         "default": {
             "type": "bi_gru",

--- a/example_experiments/siamese_sentence_selector_squad.json
+++ b/example_experiments/siamese_sentence_selector_squad.json
@@ -4,7 +4,16 @@
     "encoder": {
         "default": {
             "type": "bi_gru",
-            "output_dim": 128
+            "units": 128
+        }
+    },
+    "seq2seq_encoder": {
+        "default": {
+            "type": "bi_gru",
+            "encoder_params": {
+                "units": 100
+            },
+            "wrapper_params": {}
         }
     },
     "batch_size": 32,

--- a/tests/models/sentence_selection/test_siamese_sentence_selector.py
+++ b/tests/models/sentence_selection/test_siamese_sentence_selector.py
@@ -15,13 +15,13 @@ class TestSiameseSentenceSelector(DeepQaTestCase):
                         }
                 },
                 "seq2seq_encoder": {
-                    "default": {
-                        "type": "gru",
-                        "encoder_params": {
-                            "units": 7
-                        },
-                        "wrapper_params": {}
-                    }
+                        "default": {
+                                "type": "gru",
+                                "encoder_params": {
+                                        "units": 7
+                                },
+                                "wrapper_params": {}
+                        }
                 },
                 "embedding_dim": {"words": 5},
         }

--- a/tests/models/sentence_selection/test_siamese_sentence_selector.py
+++ b/tests/models/sentence_selection/test_siamese_sentence_selector.py
@@ -14,6 +14,15 @@ class TestSiameseSentenceSelector(DeepQaTestCase):
                                 "units": 7
                         }
                 },
+                "seq2seq_encoder": {
+                    "default": {
+                        "type": "gru",
+                        "encoder_params": {
+                            "units": 7
+                        },
+                        "wrapper_params": {}
+                    }
+                },
                 "embedding_dim": {"words": 5},
         }
         self.ensure_model_trains_and_loads(SiameseSentenceSelector, args)


### PR DESCRIPTION
Matt suggested to stack some seq2seq encoders to give the model more depth; this does so in a similar manner to the BiDAF code.

There's a funky error going on right now wrt masking the 4D input to the seq2seq encoder, and I can't quite figure it out. It complains that the mask is 2d, and the input itself is 4d...perhaps we need a `EncoderWrapper` specialized for `seq2seq_encoders`?