### PR TITLE
Multi gpu support

### DIFF
--- a/deep_qa/run.py
+++ b/deep_qa/run.py
@@ -2,6 +2,7 @@ from typing import Union, List
 import sys
 import logging
 import shutil
+import os
 
 import random
 import pyhocon
@@ -71,6 +72,7 @@ def run_model(param_path: str, model_class=None):
     # These have to be imported _after_ we set the random seed,
     # because keras uses the numpy random seed.
     from deep_qa.models import concrete_models
+    import tensorflow
     from keras import backend as K
 
     log_dir = params.get("model_serialization_prefix", None)  # pylint: disable=no-member
@@ -82,6 +84,17 @@ def run_model(param_path: str, model_class=None):
         handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(name)s - %(message)s'))
         logging.getLogger().addHandler(handler)
         shutil.copyfile(param_path, log_dir + "_model_params.json")
+
+
+    num_thread = int(os.environ.get('OMP_NUM_THREADS'))
+    config = {
+        "allow_soft_placement": True,
+        "log_device_placement": True
+    }
+    if num_thread is not None:
+        config["intra_op_parallelism_threads"] = num_thread
+    global_session = tensorflow.Session(tensorflow.ConfigProto(**config))
+    K.set_session(global_session)
 
     if model_class is None:
         model_type = params.pop_choice('model_class', concrete_models.keys())

--- a/deep_qa/run.py
+++ b/deep_qa/run.py
@@ -86,14 +86,14 @@ def run_model(param_path: str, model_class=None):
         shutil.copyfile(param_path, log_dir + "_model_params.json")
 
 
-    num_thread = int(os.environ.get('OMP_NUM_THREADS'))
+    num_thread = os.environ.get('OMP_NUM_THREADS')
     config = {
         "allow_soft_placement": True,
         "log_device_placement": True
     }
     if num_thread is not None:
-        config["intra_op_parallelism_threads"] = num_thread
-    global_session = tensorflow.Session(tensorflow.ConfigProto(**config))
+        config["intra_op_parallelism_threads"] = int(num_thread)
+    global_session = tensorflow.Session(config=tensorflow.ConfigProto(**config))
     K.set_session(global_session)
 
     if model_class is None:

--- a/deep_qa/training/callbacks.py
+++ b/deep_qa/training/callbacks.py
@@ -1,0 +1,75 @@
+
+
+from keras.callbacks import ModelCheckpoint
+import warnings
+from overrides import overrides
+
+
+class ReplicaModelCheckpoint(ModelCheckpoint):
+    """Save the model after every epoch.
+    `filepath` can contain named formatting options,
+    which will be filled the value of `epoch` and
+    keys in `logs` (passed in `on_epoch_end`).
+    For example: if `filepath` is `weights.{epoch:02d}-{val_loss:.2f}.hdf5`,
+    then the model checkpoints will be saved with the epoch number and
+    the validation loss in the filename.
+    # Arguments
+        filepath: string, path to save the model file.
+        monitor: quantity to monitor.
+        verbose: verbosity mode, 0 or 1.
+        save_best_only: if `save_best_only=True`,
+            the latest best model according to
+            the quantity monitored will not be overwritten.
+        mode: one of {auto, min, max}.
+            If `save_best_only=True`, the decision
+            to overwrite the current save file is made
+            based on either the maximization or the
+            minimization of the monitored quantity. For `val_acc`,
+            this should be `max`, for `val_loss` this should
+            be `min`, etc. In `auto` mode, the direction is
+            automatically inferred from the name of the monitored quantity.
+        save_weights_only: if True, then only the model's weights will be
+            saved (`model.save_weights(filepath)`), else the full model
+            is saved (`model.save(filepath)`).
+        period: Interval (number of epochs) between checkpoints.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(ReplicaModelCheckpoint, self).__init__(*args, **kwargs)
+
+    @overrides
+    def on_epoch_end(self, epoch, logs=None):
+        logs = logs or {}
+        num_lambda_layers = len(self.model.outputs)
+        self.epochs_since_last_save += 1
+        if self.epochs_since_last_save >= self.period:
+            self.epochs_since_last_save = 0
+            filepath = self.filepath.format(epoch=epoch, **logs)
+            if self.save_best_only:
+                current = logs.get(self.monitor)
+                if current is None:
+                    warnings.warn('Can save best model only with %s available, '
+                                  'skipping.' % (self.monitor), RuntimeWarning)
+                else:
+                    if self.monitor_op(current, self.best):
+                        if self.verbose > 0:
+                            print('Epoch %05d: %s improved from %0.5f to %0.5f,'
+                                  ' saving model to %s'
+                                  % (epoch, self.monitor, self.best,
+                                     current, filepath))
+                        self.best = current
+                        if self.save_weights_only:
+                            self.model.layers[-(num_lambda_layers+1)].save_weights(filepath, overwrite=True)
+                        else:
+                            self.model.layers[-(num_lambda_layers+1)].save(filepath, overwrite=True)
+                    else:
+                        if self.verbose > 0:
+                            print('Epoch %05d: %s did not improve' %
+                                  (epoch, self.monitor))
+            else:
+                if self.verbose > 0:
+                    print('Epoch %05d: saving model to %s' % (epoch, filepath))
+                if self.save_weights_only:
+                    self.model.layers[-(num_lambda_layers+1)].save_weights(filepath, overwrite=True)
+                else:
+                    self.model.layers[-(num_lambda_layers+1)].save(filepath, overwrite=True)

--- a/deep_qa/training/distributed-tensorflow.py
+++ b/deep_qa/training/distributed-tensorflow.py
@@ -10,8 +10,9 @@ FLAGS = None
 def main(_):
 
     # Create a cluster from the parameter server and worker hosts.
-    cluster = tf.train.ClusterSpec({"ps": ["mark-new-cuda.dev.ai2:4004"],
-                                    "worker": ["mark-new-cuda.dev.ai2:1234", "mark-new-cuda.dev.ai2:1235"]})
+    cluster = tf.train.ClusterSpec({"ps": ["markn-cpu.dev.ai2:4004"],
+                                    "worker": ["mark-new-cuda.dev.ai2:1234",
+                                               "mattg-gpu.dev.ai2:1234"]})
 
     # Create and start a server for the local task.
     server = tf.train.Server(cluster,

--- a/deep_qa/training/distributed-tensorflow.py
+++ b/deep_qa/training/distributed-tensorflow.py
@@ -1,0 +1,107 @@
+import argparse
+import sys
+
+import tensorflow as tf
+from tensorflow.examples.tutorials.mnist import input_data
+
+FLAGS = None
+
+
+def main(_):
+
+    # Create a cluster from the parameter server and worker hosts.
+    cluster = tf.train.ClusterSpec({"ps": ["host:port"], "worker": ["host:port"]})
+
+    # Create and start a server for the local task.
+    server = tf.train.Server(cluster,
+                             job_name=FLAGS.job_name,
+                             task_index=FLAGS.task_index)
+
+    if FLAGS.job_name == "ps":
+        # Workers do all the work - parameter servers are just there
+        # to host the variables. So we just make it wait until the
+        # server joins, doing absolutely jack.
+        server.join()
+    elif FLAGS.job_name == "worker":
+
+        # Assigns ops to the local worker by default.
+        # Assigns variables to a parameter server, defaulting to ps.
+        with tf.device(tf.train.replica_device_setter(
+                worker_device="/job:worker/task:%d" % FLAGS.task_index,
+                cluster=cluster)):
+
+            # input images
+            with tf.name_scope('input'):
+                # None -> batch size can be any size, 784 -> flattened mnist image
+                inputs = tf.placeholder(tf.float32, shape=[None, 784], name="x-input")
+                # target 10 output classes
+                targets = tf.placeholder(tf.float32, shape=[None, 10], name="y-input")
+
+            # model parameters will change during training so we use tf.Variable
+            tf.set_random_seed(1)
+            with tf.name_scope("weights"):
+                W1 = tf.Variable(tf.random_normal([784, 100]))
+                W2 = tf.Variable(tf.random_normal([100, 10]))
+
+            # bias
+            with tf.name_scope("biases"):
+                b1 = tf.Variable(tf.zeros([100]))
+                b2 = tf.Variable(tf.zeros([10]))
+
+            # implement model
+            with tf.name_scope("softmax"):
+                # y is our prediction
+                layer1 = tf.add(tf.matmul(inputs, W1), b1)
+                layer1 = tf.nn.sigmoid(layer1)
+                layer2 = tf.add(tf.matmul(layer1, W2), b2)
+                predictions = tf.nn.softmax(layer2)
+
+            # specify cost function
+            with tf.name_scope('loss'):
+                loss = tf.reduce_mean(-tf.reduce_sum(targets * tf.log(predictions), reduction_indices=[1]))
+
+            # Integer variable which counts gradient updates across hosts.
+            global_step = tf.train.get_or_create_global_step()
+
+            # Special optimiser wrapper which will collect gradients
+            # and then average them before applying them.
+            optimiser = tf.train.SyncReplicasOptimizer(
+                tf.train.AdagradOptimizer(0.01), 3)
+            train_op = optimiser.minimize(loss, global_step=global_step)
+
+        sync_replicas_hook = optimiser.make_session_run_hook(FLAGS.task_index==0)
+
+        # The StopAtStepHook handles stopping after running given steps.
+        hooks = [tf.train.StopAtStepHook(last_step=1000000), sync_replicas_hook]
+
+        mnist = input_data.read_data_sets('MNIST_data', one_hot=True)
+        batch_size = 64
+
+        # The MonitoredTrainingSession takes care of session initialization,
+        # restoring from a checkpoint, saving to a checkpoint, and closing when done
+        # or an error occurs.
+        with tf.train.MonitoredTrainingSession(master=server.target,
+                                               is_chief=(FLAGS.task_index == 0),
+                                               checkpoint_dir="/tmp/train_logs",
+                                               hooks=hooks) as monitored_session:
+            while not monitored_session.should_stop():
+                # Run a training step asynchronously.
+                # See `tf.train.SyncReplicasOptimizer` for additional details on how to
+                # perform *synchronous* training.
+
+                batch_inputs, batch_targets = mnist.train.next_batch(batch_size)
+                _, cost, step = monitored_session.run([train_op, loss, global_step],
+                                                      feed_dict={inputs: batch_inputs, targets: batch_targets})
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.register("type", "bool", lambda v: v.lower() == "true")
+    # Flags for defining the tf.train.ClusterSpec
+    parser.add_argument("--job_name", type=str,
+                        default="", help="One of 'ps', 'worker'")
+    # Flags for defining the tf.train.Server
+    parser.add_argument("--task_index", type=int,
+                        default=0, help="Index of task within the job")
+    FLAGS, unparsed = parser.parse_known_args()
+    tf.app.run(main=main, argv=[sys.argv[0]] + unparsed)

--- a/deep_qa/training/distributed-tensorflow.py
+++ b/deep_qa/training/distributed-tensorflow.py
@@ -10,7 +10,8 @@ FLAGS = None
 def main(_):
 
     # Create a cluster from the parameter server and worker hosts.
-    cluster = tf.train.ClusterSpec({"ps": ["host:port"], "worker": ["host:port"]})
+    cluster = tf.train.ClusterSpec({"ps": ["markn-cpu.dev.ai2:1234"],
+                                    "worker": ["mark-new-cuda.dev.ai2:1234"]})
 
     # Create and start a server for the local task.
     server = tf.train.Server(cluster,
@@ -24,6 +25,9 @@ def main(_):
         server.join()
     elif FLAGS.job_name == "worker":
 
+        # Chief worker is always the first one.
+        is_chief = FLAGS.task_index == 0
+
         # Assigns ops to the local worker by default.
         # Assigns variables to a parameter server, defaulting to ps.
         with tf.device(tf.train.replica_device_setter(
@@ -33,9 +37,9 @@ def main(_):
             # input images
             with tf.name_scope('input'):
                 # None -> batch size can be any size, 784 -> flattened mnist image
-                inputs = tf.placeholder(tf.float32, shape=[None, 784], name="x-input")
+                inputs = tf.placeholder(tf.float32, shape=[None, 784], name="inputs")
                 # target 10 output classes
-                targets = tf.placeholder(tf.float32, shape=[None, 10], name="y-input")
+                targets = tf.placeholder(tf.float32, shape=[None, 10], name="targets")
 
             # model parameters will change during training so we use tf.Variable
             tf.set_random_seed(1)
@@ -60,6 +64,8 @@ def main(_):
             with tf.name_scope('loss'):
                 loss = tf.reduce_mean(-tf.reduce_sum(targets * tf.log(predictions), reduction_indices=[1]))
 
+            tf.summary.scalar("loss", loss)
+
             # Integer variable which counts gradient updates across hosts.
             global_step = tf.train.get_or_create_global_step()
 
@@ -69,30 +75,76 @@ def main(_):
                 tf.train.AdagradOptimizer(0.01), 3)
             train_op = optimiser.minimize(loss, global_step=global_step)
 
-        sync_replicas_hook = optimiser.make_session_run_hook(FLAGS.task_index==0)
+            summary_op = tf.summary.merge_all()
+
+        ### Initialisation operations for the graph. ###
+
+        variable_init_op = tf.global_variables_initializer()
+
+        # You can now call get_init_tokens_op() and get_chief_queue_runner().
+        # Note that get_init_tokens_op() must be called before creating session
+        # because it modifies the graph.
+        local_init_op = optimiser.local_step_init_op
+
+        # Chief has a different init op, as it does more things.
+        if is_chief:
+            local_init_op = optimiser.chief_init_op
+        ready_for_local_init_op = optimiser.ready_for_local_init_op
+        # Initial token and chief queue runners required by the sync_replicas mode
+        chief_queue_runner = optimiser.get_chief_queue_runner()
+        sync_init_op = optimiser.get_init_tokens_op()
 
         # The StopAtStepHook handles stopping after running given steps.
-        hooks = [tf.train.StopAtStepHook(last_step=1000000), sync_replicas_hook]
+        hooks = [tf.train.StopAtStepHook(last_step=1000000)]
 
         mnist = input_data.read_data_sets('MNIST_data', one_hot=True)
         batch_size = 64
 
-        # The MonitoredTrainingSession takes care of session initialization,
-        # restoring from a checkpoint, saving to a checkpoint, and closing when done
-        # or an error occurs.
-        with tf.train.MonitoredTrainingSession(master=server.target,
-                                               is_chief=(FLAGS.task_index == 0),
-                                               checkpoint_dir="/tmp/train_logs",
-                                               hooks=hooks) as monitored_session:
-            while not monitored_session.should_stop():
+        # Now we create a Supervisor, which ties together some stuff which we need for training,
+        # like initialisation of the workers, finalising the graph etc.
+
+        saver = tf.train.Saver()
+        supervisor = tf.train.Supervisor(
+            is_chief=is_chief,
+            logdir="./log",
+            saver=saver,
+            summary_op=summary_op,
+            init_op=variable_init_op,
+            local_init_op=local_init_op,
+            ready_for_local_init_op=ready_for_local_init_op,
+            recovery_wait_secs=1,
+            global_step=global_step)
+
+        if is_chief:
+            print("Worker %d: Initializing session..." % FLAGS.task_index)
+        else:
+            print("Worker %d: Waiting for session to be initialized..." % FLAGS.task_index)
+
+        session_config = tf.ConfigProto(allow_soft_placement=True, log_device_placement=True)
+
+        with supervisor.prepare_or_wait_for_session(server.target, config=session_config) as session:
+
+            if is_chief:
+                # Chief worker will start the chief queue runner and call the init op.
+                session.run(sync_init_op)
+                supervisor.start_queue_runners(session, [chief_queue_runner])
+
+            while not session.should_stop():
                 # Run a training step asynchronously.
                 # See `tf.train.SyncReplicasOptimizer` for additional details on how to
                 # perform *synchronous* training.
 
                 batch_inputs, batch_targets = mnist.train.next_batch(batch_size)
-                _, cost, step = monitored_session.run([train_op, loss, global_step],
-                                                      feed_dict={inputs: batch_inputs, targets: batch_targets})
+                _, cost, step = session.run([train_op, loss, global_step],
+                                            feed_dict={inputs: batch_inputs, targets: batch_targets})
 
+                print("Worker: {}, Step: {},  Training Loss: {}".format(FLAGS.task_index, step, cost))
+
+                val_inputs, val_targets = mnist.validation.next_batch(batch_size)
+                val_loss = session.run(loss,
+                                       feed_dict={inputs: val_inputs, targets: val_targets})
+
+                print("Worker: {}, Step: {},  Validation Loss: {}".format(FLAGS.task_index, step, val_loss))
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -103,5 +155,6 @@ if __name__ == "__main__":
     # Flags for defining the tf.train.Server
     parser.add_argument("--task_index", type=int,
                         default=0, help="Index of task within the job")
+
     FLAGS, unparsed = parser.parse_known_args()
     tf.app.run(main=main, argv=[sys.argv[0]] + unparsed)

--- a/deep_qa/training/models.py
+++ b/deep_qa/training/models.py
@@ -1,7 +1,11 @@
 from overrides import overrides
 import logging
+import six
 
 from keras.models import Model, Sequential
+from keras import losses
+from keras import metrics as metrics_module
+from keras.engine.training import _weighted_masked_objective, _collect_metrics, _masked_objective
 import keras.backend as K
 import tensorflow
 
@@ -44,23 +48,6 @@ class DeepQaModel(Model):
         print_summary_with_masking(flattened_layers, getattr(self, 'container_nodes', None))
 
     @overrides
-    def compile(self, params: Params):  # pylint: disable=arguments-differ
-        # pylint: disable=attribute-defined-outside-init
-        """
-        The only reason we are overriding this method is because keras automatically wraps
-        our tensorflow optimiser in a keras wrapper, which we don't want. We override the
-        only method in ``Model`` which uses this attribute, ``_make_train_function``, which
-        raises an error if compile is not called first.
-        As we move towards using a Tensorflow first optimisation loop, more things will be
-        added here which add functionality to the way Keras runs tensorflow Session calls.
-
-        """
-        optimizer = params.get('optimizer')
-        self.gradient_clipping = params.pop("gradient_clipping", None).as_dict()
-        super(DeepQaModel, self).compile(**params.as_dict())
-        self.optimizer = optimizer
-
-    @overrides
     def _make_train_function(self):
         # pylint: disable=attribute-defined-outside-init
         """
@@ -97,6 +84,381 @@ class DeepQaModel(Model):
             updates = self.updates + [training_updates]
             # Gets loss and metrics. Updates weights at each call.
             self.train_function = K.Function(inputs, [self.total_loss] + self.metrics_tensors, updates=updates)
+
+    @overrides
+    def compile(self, params: Params):
+        """Configures the model for training.
+
+        # Arguments
+            optimizer: str (name of optimizer) or optimizer object.
+                See [optimizers](/optimizers).
+            loss: str (name of objective function) or objective function.
+                See [losses](/losses).
+                If the model has multiple outputs, you can use a different loss
+                on each output by passing a dictionary or a list of losses.
+            metrics: list of metrics to be evaluated by the model
+                during training and testing.
+                Typically you will use `metrics=['accuracy']`.
+                To specify different metrics for different outputs of a
+                multi-output model, you could also pass a dictionary,
+                such as `metrics={'output_a': 'accuracy'}`.
+            loss_weights: Optional list or dictionary specifying scalar
+                coefficients (Python floats) to weight the loss contributions
+                of different model outputs.
+                If a list, it is expected to have a 1:1 mapping
+                to the model's outputs. If a tensor, it is expected to map
+                output names (strings) to scalar coefficients.
+            sample_weight_mode: if you need to do timestep-wise
+                sample weighting (2D weights), set this to `"temporal"`.
+                `None` defaults to sample-wise weights (1D).
+                If the model has multiple outputs, you can use a different
+                `sample_weight_mode` on each output by passing a
+                dictionary or a list of modes.
+
+        # Raises
+            ValueError: In case of invalid arguments for
+                `optimizer`, `loss`, `metrics` or `sample_weight_mode`.
+        """
+        # TODO: change this to get the actual instance here rather than in Trainer
+        self.optimizer = params.pop('optimizer')
+        self.gradient_clipping = params.pop('gradient_clipping', None).as_dict()
+        self.loss = loss = params.pop('loss', {})
+        self.sample_weight_mode = sample_weight_mode = params.pop('sample_weight_mode', None)
+        self.loss_weights = loss_weights = params.pop('loss_weights', None)
+        metrics = params.pop('metrics', None)
+
+
+        # Get the loss functions for all the outputs of the model.
+        # TODO: see if this has to be an attribute, it's only used in this function in model.
+        self.loss_functions = self.get_loss_functions(loss)
+        weighted_losses = [_weighted_masked_objective(fn) for fn in self.loss_functions]
+
+        skip_indices = []
+        self._feed_outputs = []
+        self._feed_output_names = []
+        self._feed_output_shapes = []
+        self._feed_loss_fns = []
+        for i in range(len(weighted_losses)):
+            if weighted_losses[i] is None:
+                skip_indices.append(i)
+            else:
+                self._feed_outputs.append(self.outputs[i])
+                self._feed_output_names.append(self.output_names[i])
+                self._feed_output_shapes.append(self.internal_output_shapes[i])
+                self._feed_loss_fns.append(self.loss_functions[i])
+
+        # Prepare output masks.
+        masks = self.compute_mask(self.inputs, mask=None)
+        if masks is None:
+            masks = [None for _ in self.outputs]
+        if not isinstance(masks, list):
+            masks = [masks]
+
+        # Prepare loss weights.
+        loss_weights_list = self.get_loss_weights(loss_weights)
+
+        # Prepare sample weights.
+        sample_weights, self.sample_weight_modes = self.get_sample_weights(sample_weight_mode, skip_indices)
+        self._feed_sample_weight_modes = []
+        for i in range(len(self.outputs)):
+            if i not in skip_indices:
+                self._feed_sample_weight_modes.append(self.sample_weight_modes[i])
+
+        # Prepare targets of model.
+        self.targets = []
+        self._feed_targets = []
+        for i in range(len(self.outputs)):
+            if i in skip_indices:
+                self.targets.append(None)
+            else:
+                shape = self.internal_output_shapes[i]
+                name = self.output_names[i]
+                target = K.placeholder(ndim=len(shape),
+                                       name=name + '_target',
+                                       sparse=K.is_sparse(self.outputs[i]),
+                                       dtype=K.dtype(self.outputs[i]))
+                self.targets.append(target)
+                self._feed_targets.append(target)
+
+        # Prepare metrics.
+        self.metrics = metrics
+        self.metrics_names = ['loss']
+        self.metrics_tensors = []
+
+        # Compute total loss.
+        total_loss = None
+        for i in range(len(self.outputs)):
+            if i in skip_indices:
+                continue
+            y_true = self.targets[i]
+            y_pred = self.outputs[i]
+            weighted_loss = weighted_losses[i]
+            sample_weight = sample_weights[i]
+            mask = masks[i]
+            loss_weight = loss_weights_list[i]
+            output_loss = weighted_loss(y_true, y_pred,
+                                        sample_weight, mask)
+            if len(self.outputs) > 1:
+                self.metrics_tensors.append(output_loss)
+                self.metrics_names.append(self.output_names[i] + '_loss')
+            if total_loss is None:
+                total_loss = loss_weight * output_loss
+            else:
+                total_loss += loss_weight * output_loss
+        if total_loss is None:
+            if not self.losses:
+                raise RuntimeError('The model cannot be compiled '
+                                   'because it has no loss to optimize.')
+            else:
+                total_loss = 0.
+
+        # Add regularization penalties
+        # and other layer-specific losses.
+        for loss_tensor in self.losses:
+            total_loss += loss_tensor
+
+        # List of same size as output_names.
+        # contains tuples (metrics for output, names of metrics).
+        nested_metrics = _collect_metrics(metrics, self.output_names)
+
+        def append_metric(layer_num, metric_name, metric_tensor):
+            """Helper function used in loop below."""
+            if len(self.output_names) > 1:
+                metric_name = self.output_layers[layer_num].name + '_' + metric_name
+            self.metrics_names.append(metric_name)
+            self.metrics_tensors.append(metric_tensor)
+
+        for i in range(len(self.outputs)):
+            if i in skip_indices:
+                continue
+            y_true = self.targets[i]
+            y_pred = self.outputs[i]
+            output_metrics = nested_metrics[i]
+            for metric in output_metrics:
+                if metric == 'accuracy' or metric == 'acc':
+                    # custom handling of accuracy
+                    # (because of class mode duality)
+                    output_shape = self.internal_output_shapes[i]
+                    acc_fn = None
+                    if (output_shape[-1] == 1 or
+                       self.loss_functions[i] == losses.binary_crossentropy):
+                        # case: binary accuracy
+                        acc_fn = metrics_module.binary_accuracy
+                    elif self.loss_functions[i] == losses.sparse_categorical_crossentropy:
+                        # case: categorical accuracy with sparse targets
+                        acc_fn = metrics_module.sparse_categorical_accuracy
+                    else:
+                        acc_fn = metrics_module.categorical_accuracy
+
+                    masked_fn = _masked_objective(acc_fn)
+                    append_metric(i, 'acc', masked_fn(y_true, y_pred, mask=masks[i]))
+                else:
+                    metric_fn = metrics_module.get(metric)
+                    masked_metric_fn = _masked_objective(metric_fn)
+                    metric_result = masked_metric_fn(y_true, y_pred, mask=masks[i])
+                    metric_result = {
+                        metric_fn.__name__: metric_result
+                    }
+                    for name, tensor in six.iteritems(metric_result):
+                        append_metric(i, name, tensor)
+
+        # Prepare gradient updates and state updates.
+        self.total_loss = total_loss
+        self.sample_weights = sample_weights
+        self._feed_sample_weights = []
+        for i in range(len(self.sample_weights)):
+            if i not in skip_indices:
+                self._feed_sample_weights.append(sample_weights[i])
+
+        # Functions for train, test and predict will
+        # be compiled lazily when required.
+        # This saves time when the user is not using all functions.
+        self.train_function = None
+        self.test_function = None
+        self.predict_function = None
+
+        # Collected trainable weights and sort them deterministically.
+        trainable_weights = self.trainable_weights
+        # Sort weights by name.
+        if trainable_weights:
+            if K.backend() == 'theano':
+                trainable_weights.sort(key=lambda x: x.name if x.name else x.auto_name)
+            else:
+                trainable_weights.sort(key=lambda x: x.name)
+        self._collected_trainable_weights = trainable_weights
+
+
+    def get_loss_functions(self, loss):
+
+        """
+        STEP 1 of Model.compile. Build the loss functions for each of the outputs
+        of the model.
+        """
+
+        # Prepare loss functions.
+        if isinstance(loss, dict):
+            for name in loss:
+                if name not in self.output_names:
+                    raise ValueError('Unknown entry in loss '
+                                     'dictionary: "' + name + '". '
+                                     'Only expected the following keys: ' +
+                                     str(self.output_names))
+            loss_functions = []
+            for name in self.output_names:
+                if name not in loss:
+                    logger.warning('Output "' + name +
+                                  '" missing from loss dictionary. '
+                                  'We assume this was done on purpose, '
+                                  'and we will not be expecting '
+                                  'any data to be passed to "' + name +
+                                  '" during training.')
+                loss_functions.append(losses.get(loss.get(name)))
+        elif isinstance(loss, list):
+            if len(loss) != len(self.outputs):
+                raise ValueError('When passing a list as loss, '
+                                 'it should have one entry per model outputs. '
+                                 'The model has ' + str(len(self.outputs)) +
+                                 ' outputs, but you passed loss=' +
+                                 str(loss))
+            loss_functions = [losses.get(l) for l in loss]
+        else:
+            loss_function = losses.get(loss)
+            loss_functions = [loss_function for _ in range(len(self.outputs))]
+
+        return loss_functions
+
+    def get_loss_weights(self, loss_weights):
+
+        """
+        STEP 2 of Model.compile: if we are weighting the losses, extract them from
+        the variety of formats keras supports for this.
+        """
+
+        if loss_weights is None:
+            loss_weights_list = [1. for _ in range(len(self.outputs))]
+        elif isinstance(loss_weights, dict):
+            for name in loss_weights:
+                if name not in self.output_names:
+                    raise ValueError('Unknown entry in loss_weights '
+                                     'dictionary: "' + name + '". '
+                                     'Only expected the following keys: ' +
+                                     str(self.output_names))
+            loss_weights_list = []
+            for name in self.output_names:
+                loss_weights_list.append(loss_weights.get(name, 1.))
+        elif isinstance(loss_weights, list):
+            if len(loss_weights) != len(self.outputs):
+                raise ValueError('When passing a list as loss_weights, '
+                                 'it should have one entry per model outputs. '
+                                 'The model has ' + str(len(self.outputs)) +
+                                 ' outputs, but you passed loss_weights=' +
+                                 str(loss_weights))
+            loss_weights_list = loss_weights
+        else:
+            raise TypeError('Could not interpret loss_weights argument: ' +
+                            str(loss_weights) +
+                            ' - expected a list of dicts.')
+
+        return loss_weights_list
+
+    def get_sample_weights(self, sample_weight_mode, skip_indices):
+
+        """
+        STEP #: Get the sample weights....
+        """
+
+        sample_weights = []
+        sample_weight_modes = []
+        if isinstance(sample_weight_mode, dict):
+            for name in sample_weight_mode:
+                if name not in self.output_names:
+                    raise ValueError('Unknown entry in '
+                                     'sample_weight_mode dictionary: "' +
+                                     name + '". '
+                                     'Only expected the following keys: ' +
+                                     str(self.output_names))
+            for i, name in enumerate(self.output_names):
+                if i in skip_indices:
+                    weight = None
+                    sample_weight_modes.append(None)
+                else:
+                    if name not in sample_weight_mode:
+                        raise ValueError('Output "' + name +
+                                         '" missing from sample_weight_modes '
+                                         'dictionary')
+                    if sample_weight_mode.get(name) == 'temporal':
+                        weight = K.placeholder(ndim=2,
+                                               name=name + '_sample_weights')
+                        sample_weight_modes.append('temporal')
+                    else:
+                        weight = K.placeholder(ndim=1,
+                                               name=name + '_sample_weights')
+                        sample_weight_modes.append(None)
+                sample_weights.append(weight)
+        elif isinstance(sample_weight_mode, list):
+            if len(sample_weight_mode) != len(self.outputs):
+                raise ValueError('When passing a list as sample_weight_mode, '
+                                 'it should have one entry per model outputs. '
+                                 'The model has ' + str(len(self.outputs)) +
+                                 ' outputs, but you passed '
+                                 'sample_weight_mode=' +
+                                 str(sample_weight_mode))
+            for i in range(len(self.output_names)):
+                if i in skip_indices:
+                    weight = None
+                    sample_weight_modes.append(None)
+                else:
+                    mode = sample_weight_mode[i]
+                    name = self.output_names[i]
+                    if mode == 'temporal':
+                        weight = K.placeholder(ndim=2,
+                                               name=name + '_sample_weights')
+                        sample_weight_modes.append('temporal')
+                    else:
+                        weight = K.placeholder(ndim=1,
+                                               name=name + '_sample_weights')
+                        sample_weight_modes.append(None)
+                sample_weights.append(weight)
+        else:
+            for i, name in enumerate(self.output_names):
+                if i in skip_indices:
+                    sample_weight_modes.append(None)
+                    sample_weights.append(None)
+                else:
+                    if sample_weight_mode == 'temporal':
+                        sample_weights.append(
+                            K.placeholder(ndim=2,
+                                          name=name + '_sample_weights'))
+                        sample_weight_modes.append('temporal')
+                    else:
+                        sample_weights.append(
+                            K.placeholder(ndim=1,
+                                          name=name + '_sample_weights'))
+                        sample_weight_modes.append(None)
+
+        return sample_weights, sample_weight_modes
+
+    def _make_test_function(self):
+
+        """
+        Only difference here: We don't use **kwargs in the K.function call,
+        as they are only supported by Theano anyway.
+        """
+
+        if not hasattr(self, 'test_function'):
+            raise RuntimeError('You must compile your model before using it.')
+        if self.test_function is None:
+            inputs = self._feed_inputs + self._feed_targets + self._feed_sample_weights
+            if self.uses_learning_phase and not isinstance(K.learning_phase(), int):
+                inputs += [K.learning_phase()]
+            # Return loss and metrics, no gradient updates.
+            # Does update the network states.
+            self.test_function = K.function(inputs,
+                                            [self.total_loss] + self.metrics_tensors,
+                                            updates=self.state_updates)
+
+
+
 
 
 def print_summary_with_masking(layers, relevant_nodes=None):

--- a/deep_qa/training/models.py
+++ b/deep_qa/training/models.py
@@ -1,5 +1,5 @@
-import logging
 from overrides import overrides
+import logging
 
 from keras.models import Model, Sequential
 import keras.backend as K
@@ -190,3 +190,40 @@ def count_total_params(layers, layer_set=None):
         else:
             total_params += layer.count_params()
     return total_params
+
+
+def _slice_arrays(arrays, start=None, stop=None):
+    """Slice an array or list of arrays.
+
+    This takes an array-like, or a list of
+    array-likes, and outputs:
+        - arrays[start:stop] if `arrays` is an array-like
+        - [x[start:stop] for x in arrays] if `arrays` is a list
+
+    Can also work on list/array of indices: `_slice_arrays(x, indices)`
+
+    # Arguments
+        arrays: Single array or list of arrays.
+        start: can be an integer index (start index)
+            or a list/array of indices
+        stop: integer (stop index); should be None if
+            `start` was a list.
+
+    # Returns
+        A slice of the array(s).
+    """
+    if isinstance(arrays, list):
+        if hasattr(start, '__len__'):
+            # hdf5 datasets only support list objects as indices
+            if hasattr(start, 'shape'):
+                start = start.tolist()
+            return [x[start] for x in arrays]
+        else:
+            return [x[start:stop] for x in arrays]
+    else:
+        if hasattr(start, '__len__'):
+            if hasattr(start, 'shape'):
+                start = start.tolist()
+            return arrays[start]
+        else:
+            return arrays[start:stop]

--- a/deep_qa/training/multi_gpu.py
+++ b/deep_qa/training/multi_gpu.py
@@ -1,0 +1,47 @@
+from keras.layers import merge
+from keras.layers.core import Lambda
+from keras.models import Model
+
+import tensorflow as tf
+
+
+def make_parallel(model, gpu_count):
+    def get_slice(data, idx, parts):
+        shape = tf.shape(data)
+        size = tf.concat([shape[:1] // parts, shape[1:]], axis=0)
+        stride = tf.concat([shape[:1] // parts, shape[1:] * 0], axis=0)
+        start = stride * idx
+        return tf.slice(data, start, size)
+
+    outputs_all = []
+    for i in range(len(model.outputs)):
+        outputs_all.append([])
+
+    # Place a copy of the model on each GPU, each getting a slice of the batch
+    for i in range(gpu_count):
+        with tf.device('/gpu:%d' % i):
+            with tf.name_scope('tower_%d' % i) as scope:
+
+                inputs = []
+                # Slice each input into a piece for processing on this GPU
+                for x in model.inputs:
+                    input_shape = tuple(x.get_shape().as_list())[1:]
+                    slice_n = Lambda(get_slice, output_shape=input_shape, arguments={'idx': i, 'parts': gpu_count})(x)
+                    inputs.append(slice_n)
+
+                outputs = model(inputs)
+
+                if not isinstance(outputs, list):
+                    outputs = [outputs]
+
+                # Save all the outputs for merging back together later
+                for l in range(len(outputs)):
+                    outputs_all[l].append(outputs[l])
+
+    # merge outputs on CPU
+    with tf.device('/cpu:0'):
+        merged = []
+        for outputs in outputs_all:
+            merged.append(merge(outputs, mode='concat', concat_axis=0))
+
+        return Model(input=model.inputs, output=merged)

--- a/deep_qa/training/multi_gpu.py
+++ b/deep_qa/training/multi_gpu.py
@@ -7,9 +7,13 @@ import tensorflow as tf
 def make_parallel(model: DeepQaModel, gpu_count: int) -> DeepQaModel:
 
     """
-    :param model: An instance of a DeepQaModel.
-    :param gpu_count: The number of GPUs to duplicate the model across.
-    :return: A new DeepQaModel, consisting of model_duplicates over
+    Parameters
+    ----------
+    model: An instance of a DeepQaModel.
+    gpu_count: The number of GPUs to duplicate the model across.
+
+    Output:
+    - A new DeepQaModel, consisting of model_duplicates over
         the number of available GPUs.
     """
     # Argument to a Lambda layer which will slice our large batches

--- a/deep_qa/training/multi_gpu.py
+++ b/deep_qa/training/multi_gpu.py
@@ -1,11 +1,19 @@
 from keras.layers import merge
 from keras.layers.core import Lambda
-from keras.models import Model
-
+from .models import DeepQaModel
 import tensorflow as tf
 
 
-def make_parallel(model, gpu_count):
+def make_parallel(model: DeepQaModel, gpu_count: int):
+
+    """
+    :param model: An instance of a DeepQaModel.
+    :param gpu_count: The number of GPUs to duplicate the model across.
+    :return:
+    """
+
+    # Argument to a Lambda layer which will slice our large batches
+    # along the batch dimension and return a given slice.
     def get_slice(data, idx, parts):
         shape = tf.shape(data)
         size = tf.concat([shape[:1] // parts, shape[1:]], axis=0)
@@ -17,16 +25,21 @@ def make_parallel(model, gpu_count):
     for i in range(len(model.outputs)):
         outputs_all.append([])
 
-    # Place a copy of the model on each GPU, each getting a slice of the batch
+    # Place a copy of the model on each GPU, each getting a slice of the batch.
     for i in range(gpu_count):
         with tf.device('/gpu:%d' % i):
             with tf.name_scope('tower_%d' % i) as scope:
 
                 inputs = []
-                # Slice each input into a piece for processing on this GPU
-                for x in model.inputs:
-                    input_shape = tuple(x.get_shape().as_list())[1:]
-                    slice_n = Lambda(get_slice, output_shape=input_shape, arguments={'idx': i, 'parts': gpu_count})(x)
+                # Slice each input into a piece for processing on this GPU.
+                for model_input in model.inputs:
+                    # Get the shape of everything apart from the batch,
+                    # which will be split across the GPUs.
+                    output_shape = tuple(model_input.get_shape().as_list())[1:]
+                    slice_layer = Lambda(get_slice,
+                                         output_shape=output_shape,
+                                         arguments={'idx': i, 'parts': gpu_count})
+                    slice_n = slice_layer(model_input)
                     inputs.append(slice_n)
 
                 outputs = model(inputs)
@@ -35,8 +48,8 @@ def make_parallel(model, gpu_count):
                     outputs = [outputs]
 
                 # Save all the outputs for merging back together later
-                for l in range(len(outputs)):
-                    outputs_all[l].append(outputs[l])
+                for output_index in range(len(outputs)):
+                    outputs_all[output_index].append(outputs[output_index])
 
     # merge outputs on CPU
     with tf.device('/cpu:0'):
@@ -44,4 +57,4 @@ def make_parallel(model, gpu_count):
         for outputs in outputs_all:
             merged.append(merge(outputs, mode='concat', concat_axis=0))
 
-        return Model(input=model.inputs, output=merged)
+        return DeepQaModel(input=model.inputs, output=merged)

--- a/deep_qa/training/text_trainer.py
+++ b/deep_qa/training/text_trainer.py
@@ -296,7 +296,13 @@ class TextTrainer(Trainer):
         uses both words and characters, we need to run the character encoder and concatenate the
         result with a word embedding).
         """
-        return self.tokenizer.embed_input(input_layer, self.__get_embedded_input, self, embedding_name)
+        with tensorflow.device("/cpu:0"):
+            embedded_input = self.tokenizer.embed_input(input_layer,
+                                                        self.__get_embedded_input,
+                                                        self,
+                                                        embedding_name)
+
+        return embedded_input
 
     def _get_encoder(self, name="default", fallback_behavior: str=None):
         """

--- a/deep_qa/training/text_trainer.py
+++ b/deep_qa/training/text_trainer.py
@@ -296,13 +296,10 @@ class TextTrainer(Trainer):
         uses both words and characters, we need to run the character encoder and concatenate the
         result with a word embedding).
         """
-        with tensorflow.device("/cpu:0"):
-            embedded_input = self.tokenizer.embed_input(input_layer,
-                                                        self.__get_embedded_input,
-                                                        self,
-                                                        embedding_name)
-
-        return embedded_input
+        return self.tokenizer.embed_input(input_layer,
+                                          self.__get_embedded_input,
+                                          self,
+                                          embedding_name)
 
     def _get_encoder(self, name="default", fallback_behavior: str=None):
         """

--- a/deep_qa/training/trainer.py
+++ b/deep_qa/training/trainer.py
@@ -3,6 +3,7 @@ import os
 from typing import Any, Dict, List, Tuple
 
 import numpy
+import tensorflow
 from keras.models import model_from_json
 from keras.callbacks import LambdaCallback, TensorBoard, EarlyStopping, CallbackList, ModelCheckpoint
 from ..training.callbacks import ReplicaModelCheckpoint
@@ -291,9 +292,9 @@ class Trainer:
         logger.info("Building the model")
         self.model = self._build_model()
 
-        self.model.summary(show_masks=self.show_summary_with_masking)
         if self.num_gpus > 1:
-            self.model = make_parallel(self.model, self.num_gpus)
+            with tensorflow.device("/cpu:0"):
+                self.model = make_parallel(self.model, self.num_gpus)
 
         self.model.summary(show_masks=self.show_summary_with_masking)
         self.model.compile(self.__compile_kwargs())

--- a/deep_qa/training/trainer.py
+++ b/deep_qa/training/trainer.py
@@ -13,6 +13,7 @@ from ..data.instances.instance import Instance
 from ..layers.wrappers import OutputMask
 from .models import DeepQaModel
 from .optimizers import optimizer_from_params
+from .multi_gpu import make_parallel
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -148,8 +149,11 @@ class Trainer:
             os.makedirs(parent_directory, exist_ok=True)
 
         # `model.fit()` parameters.
+        self.num_gpus = params.pop("num_gpus", 2)
         self.validation_split = params.pop('validation_split', 0.1)
         self.batch_size = params.pop('batch_size', 32)
+        self.batch_size *= self.num_gpus
+
         self.num_epochs = params.pop('num_epochs', 20)
         self.optimizer = optimizer_from_params(params.pop('optimizer', 'adam'))
         self.gradient_clipping = params.pop('gradient_clipping', {'type': 'clip_by_norm', "value": 10})
@@ -282,6 +286,10 @@ class Trainer:
         # Then we build the model and compile it.
         logger.info("Building the model")
         self.model = self._build_model()
+
+        if self.num_gpus > 1:
+            self.model = make_parallel(self.model, self.num_gpus)
+
         self.model.summary(show_masks=self.show_summary_with_masking)
         self.model.compile(self.__compile_kwargs())
 

--- a/deep_qa/training/trainer.py
+++ b/deep_qa/training/trainer.py
@@ -297,7 +297,6 @@ class Trainer:
 
         self.model.summary(show_masks=self.show_summary_with_masking)
         self.model.compile(self.__compile_kwargs())
-        self.model.compile(**self.__compile_kwargs())
 
         if self.debug_params:
             # Get the list of layers whose outputs will be visualized as per the

--- a/deep_qa/training/trainer.py
+++ b/deep_qa/training/trainer.py
@@ -149,10 +149,14 @@ class Trainer:
             os.makedirs(parent_directory, exist_ok=True)
 
         # `model.fit()` parameters.
-        self.num_gpus = params.pop("num_gpus", 2)
+        self.num_gpus = params.pop("num_gpus", 1)
         self.validation_split = params.pop('validation_split', 0.1)
         self.batch_size = params.pop('batch_size', 32)
-        self.batch_size *= self.num_gpus
+
+        # If you've got more than one gpu, we make a mega batch, which then
+        # gets split across the number of gpus you have.
+        if self.num_gpus > 1:
+            self.batch_size *= self.num_gpus
 
         self.num_epochs = params.pop('num_epochs', 20)
         self.optimizer = optimizer_from_params(params.pop('optimizer', 'adam'))
@@ -287,11 +291,13 @@ class Trainer:
         logger.info("Building the model")
         self.model = self._build_model()
 
+        self.model.summary(show_masks=self.show_summary_with_masking)
         if self.num_gpus > 1:
             self.model = make_parallel(self.model, self.num_gpus)
 
         self.model.summary(show_masks=self.show_summary_with_masking)
         self.model.compile(self.__compile_kwargs())
+        self.model.compile(**self.__compile_kwargs())
 
         if self.debug_params:
             # Get the list of layers whose outputs will be visualized as per the

--- a/deep_qa/training/trainer.py
+++ b/deep_qa/training/trainer.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Tuple
 import numpy
 from keras.models import model_from_json
 from keras.callbacks import LambdaCallback, TensorBoard, EarlyStopping, CallbackList, ModelCheckpoint
-
+from ..training.callbacks import ReplicaModelCheckpoint
 from ..common.checks import ConfigurationError
 from ..common.params import Params
 from ..data.dataset import Dataset, IndexedDataset
@@ -525,9 +525,11 @@ class Trainer:
         # Some witchcraft is happening here - we don't specify the epoch replacement variable
         # checkpointing string, because Keras does that within the callback if we specify it here.
         if self.save_models:
+
+            #checkpoint_callback = ReplicaModelCheckpoint if self.num_gpus > 1 else ModelCheckpoint
             checkpointing = ModelCheckpoint(self.model_prefix + "_weights_epoch={epoch:d}.h5",
-                                            save_best_only=True, save_weights_only=True,
-                                            monitor=self.validation_metric)
+                                                save_best_only=True, save_weights_only=True,
+                                                monitor=self.validation_metric)
             callbacks.append(checkpointing)
 
         return CallbackList(callbacks)

--- a/tests/training/multi_gpu_test.py
+++ b/tests/training/multi_gpu_test.py
@@ -44,11 +44,11 @@ class TestMultiGpu(DeepQaTestCase):
         model = self.get_model(ClassificationModel, self.args)
         model.train()
 
-        print(model.model.layers)
         trainable_variables = model.model.trainable_weights
-
         for variable in trainable_variables:
-            assert variable.device == "/cpu:0" or variable.device == ""
+            # This is an odd quirk of tensorflow - the devices are actually named
+            # slightly differently from their scopes ... (i.e != "/cpu:0")
+            assert variable.device == "/device:CPU:0" or variable.device == ""
 
     def test_multi_gpu_shares_variables(self):
 
@@ -65,8 +65,6 @@ class TestMultiGpu(DeepQaTestCase):
         single_gpu_model.train()
         single_gpu_variables = [x.name for x in single_gpu_model.model.trainable_weights]
 
-        print("Single GPU:", single_gpu_variables)
-        print("Multi GPU:", multi_gpu_variables)
         assert single_gpu_variables == multi_gpu_variables
 
 

--- a/tests/training/multi_gpu_test.py
+++ b/tests/training/multi_gpu_test.py
@@ -1,0 +1,52 @@
+# pylint: disable=no-self-use,invalid-name
+
+
+import tensorflow
+import keras.backend as K
+from deep_qa.common.params import Params, pop_choice
+from deep_qa.models.text_classification import ClassificationModel
+from ..common.test_case import DeepQaTestCase
+
+
+class TestMultiGpu(DeepQaTestCase):
+    # pylint: disable=protected-access
+
+    def setUp(self):
+        super(TestMultiGpu, self).setUp()
+        self.write_true_false_model_files()
+        self.args = Params({
+                    'embedding_dim': {'words': 4, 'characters': 2},
+                    'batch_size': 8,
+                    'num_gpus': 2,
+                    'save_models': True,
+                    'show_summary_with_masking_info': True,
+            })
+
+    def test_model_can_train(self):
+
+        model = self.get_model(ClassificationModel, self.args)
+        model.train()
+
+    def test_multi_gpu_shares_variables(self):
+
+        multi_gpu_model = self.get_model(ClassificationModel, self.args)
+        self.args['num_gpus'] = 1
+        single_gpu_model = self.get_model(ClassificationModel, self.args)
+
+        multi_gpu_model.train()
+        multi_gpu_variables = [x.name for x in multi_gpu_model.model.trainable_weights]
+
+        K.clear_session()
+        single_gpu_model.train()
+        single_gpu_variables = [x.name for x in single_gpu_model.model.trainable_weights]
+
+        print("Single GPU:", single_gpu_variables)
+        print("Multi GPU:", multi_gpu_variables)
+        assert single_gpu_variables == multi_gpu_variables
+
+
+
+
+
+
+


### PR DESCRIPTION
This PR adds data parallelism which allows batch updates to be split across any number of GPUs with synchronous gradient updates performed on the CPU. 

Additionally, I've added a tensorflow device scope to the `_embed_input` function, which should locate all embedding variables on the CPU. 

There are a few things to decide here:
1) Default behaviour when the number of available GPUS is not what it is in the model parameters. At the moment (and by default in Keras), we enable `soft_device_placement=True` in the session configuration, which means that tensorflow will try to put things on specified GPUs, but won't complain if they aren't available and will just allocate them some other way if the devices aren't there.

2) Should we keep the device_placement logging/make it a parameter? It will print all of the operations in the graph and what device they are on, which is a lot of stuff, but also extremely helpful for debugging etc.

