### PR TITLE
possible way to get READMEs into docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ the details of your model based on the data that you're working with.
 code for these systems is typically 50 lines or less.
 
 
+This library has several main components:
+
+* A ``training`` module, which has a bunch of helper code for training Keras models of various
+  kinds.
+* A ``models`` module, containing implementations of actual Keras models grouped around various
+  prediction tasks.
+* A ``layers`` module, which contains code for custom Keras Layers that we have written.
+* A ``data`` module, containing code for reading in data from files and converting it into numpy
+  arrays suitable for use with Keras.
+* A ``common`` module, which has a few random things dealing with reading parameters and a few
+  other things.
+
 ## Working in a clone of DeepQA
 
 To train or evaluate a model using a clone of the DeepQA repository, the recommended entry point is

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,15 +5,15 @@ Status](https://readthedocs.org/projects/deep-qa/badge/?version=latest)](http://
 [![codecov](https://codecov.io/gh/allenai/deep_qa/branch/master/graph/badge.svg)](https://codecov.io/gh/allenai/deep_qa)
 
 
-# Changes since the last release
+## Changes since the last release
 
-### Features
+#### Features
 
-### Bug fixes
+#### Bug fixes
 
-### Breaking API changes
+#### Breaking API changes
 
 
-# Release 0.1.0
+## Release 0.1.0
 
 Initial Release of deep_qa.

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -6,8 +6,16 @@ MAKE_TARGET=html-strict
 
 source activate testenv
 
+# Create .rst versions of the .md files we need for the docs.
+pandoc --from=markdown --to=rst --output=README.rst README.md
+pandoc --from=markdown --to=rst --output=RELEASE.rst RELEASE.md
+
 # The pipefail is requested to propagate exit code
 set -o pipefail && cd doc && make $MAKE_TARGET 2>&1 | tee ~/log.txt
 
 echo "Finished building docs."
 echo "Artifacts in $CIRCLE_ARTIFACTS"
+
+# Cleanup .rst files we created.
+rm ../README.rst
+rm ../RELEASE.rst

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -6,45 +6,15 @@
 Home
 ====
 
-DeepQA is a library built on top of Keras to make NLP easier.  There are four main benefits to
-this library:
+.. include:: ../README.rst
 
-#. It is hard to get NLP right in Keras.  There are a lot of issues around padding sequences and
-   masking that are not handled well in the main Keras code, and we have well-tested code that
-   does the right thing for, e.g., computing attentions over padded sequences, or distributing text
-   encoders across several sentences or words.
-#. We have implemented a base class, :class:`~deep_qa.training.text_trainer.TextTrainer`, that
-   provides a nice, consistent API around building NLP models in Keras.  This API has functionality
-   around processing data instances, embedding words and/or characters, easily getting various
-   kinds of sentence encoders, and so on.
-#. We provide a nice interface to training, validating, and debugging Keras models.  It is very
-   easy to experiment with variants of a model family, just by changing some parameters in a JSON
-   file.  For example, you can go from using fixed GloVe vectors to represent words, to fine-tuning
-   those embeddings, to using a concatenation of word vectors and a character-level CNN to
-   represent words, just by changing parameters in a JSON experiment file.  If your model is built
-   using the ``TextTrainer`` API, all of this works transparently to the model class - the model
-   just knows that it's getting some kind of word vector.
-#. We have implemented a number of state-of-the-art models, particularly focused around question
-   answering systems (though we've dabbled in models for other tasks, as well).  The actual model
-   code for these systems are typically 50 lines or less.
-
-This library has several main components:
-
-* A ``training`` module, which has a bunch of helper code for training Keras models of various
-  kinds.
-* A ``models`` module, containing implementations of actual Keras models grouped around various
-  prediction tasks.
-* A ``layers`` module, which contains code for custom Keras Layers that we have written.
-* A ``data`` module, containing code for reading in data from files and converting it into numpy
-  arrays suitable for use with Keras.
-* A ``common`` module, which has a few random things dealing with reading parameters and a few
-  other things.
 
 .. toctree::
    :hidden:
 
    self
    run
+   releases
 
 .. toctree::
    :caption: Training

--- a/doc/releases.rst
+++ b/doc/releases.rst
@@ -1,0 +1,5 @@
+Release Notes
+=============
+
+.. include:: ../RELEASE.rst
+:show-inheritance:


### PR DESCRIPTION
Here is a possible way to get the .md files in the docs - not ideal to have to convert them and it also means we can't use relative github paths in the .md files, but it seems to work.

I tried doing the way you suggested in #314, but I couldn't get it to recognise the imported .md file - I tried several ways of doing this, including switching index.rst over to a md file. 

I wanted to see what you thought initially with this approach before I clean up the links and include more of the readmes in the other directories. 